### PR TITLE
Extend query language: access JSON arrays

### DIFF
--- a/backend/kangas/server/computed_columns.py
+++ b/backend/kangas/server/computed_columns.py
@@ -13,9 +13,11 @@
 
 import ast
 
+import astor
+
 ## FIXME:
-## 1. No support for substrings, or [:]
-## 2. No support for JSON lists
+## 1. No support for substrings
+## 2. No support for slices, [:]
 
 
 class AttributeNode:
@@ -121,6 +123,19 @@ class Evaluator:
                 aggregate_selection_name = "%s_aggregate_column_%s" % (function_name, 1)
                 self.selections[aggregate_selection_name] = expr
                 return aggregate_selection_name
+            elif function_name in ["any", "all", "len"]:
+                ## Sqlite functions
+                function_map = {
+                    "any": "ANY_IN_GROUP",
+                    "all": "ALL_IN_GROUP",
+                    "len": "length",
+                }
+                sargs = ", ".join([str(arg) for arg in args])
+                expr = "{function_name}({sargs})".format(
+                    function_name=function_map[function_name],
+                    sargs=sargs,
+                )
+                return expr
             elif function_name in ["abs", "round", "max", "min"]:
                 # Special case to deal with Python's min([...]), max([...])
                 # to turn into SQL's min(...), max(...)
@@ -135,12 +150,6 @@ class Evaluator:
                     return "CAST(%s AS int)" % expr
                 else:
                     return expr
-            elif function_name == "len":
-                sargs = ", ".join([str(arg) for arg in args])
-                expr = "length({sargs})".format(
-                    sargs=sargs,
-                )
-                return expr
             elif isinstance(function_name, AttributeNode):
                 if function_name.obj == "random":
                     if function_name.attr == "random":
@@ -416,12 +425,30 @@ class Evaluator:
         elif isinstance(node, ast.Str):
             ## Python 3.7
             return repr(node.s)
+        elif isinstance(node, ast.ListComp):
+            # [x for y in json_list if ...]
+            # [x.label == 'hello' for x in {"image"}.overlays if ...]
+            x = astor.to_source(node.elt).strip()
+            y = astor.to_source(node.generators[0].target).strip()
+            json_list = self.eval_node(node.generators[0].iter)
+            ifs = [astor.to_source(node).strip() for node in node.generators[0].ifs]
+            return 'ListComprehension("%s", "%s", %s, "%s")' % (
+                escape(x),
+                escape(y),
+                escape(json_list),
+                escape(ifs),
+            )
+
         raise TypeError(node)
+
+
+def escape(string):
+    return str(string).replace('"', "'")
 
 
 def eval_computed_columns(computed_columns, where_expr=None):
     """
-    Takes: list of computed_columns '{
+    Takes: list of computed_columns: {
       "New date": {
          "field_expr": "{'date'} + 7",
          "field_name": "cc1"
@@ -461,7 +488,11 @@ def eval_computed_columns(computed_columns, where_expr=None):
     if where_expr:
         where_sql = evaluator.eval_expr(where_expr)
 
-    return (new_columns, evaluator.selections, where_sql)
+    return (
+        new_columns,
+        evaluator.selections,
+        where_sql,
+    )
 
 
 def update_state(

--- a/backend/kangas/server/computed_columns.py
+++ b/backend/kangas/server/computed_columns.py
@@ -123,12 +123,13 @@ class Evaluator:
                 aggregate_selection_name = "%s_aggregate_column_%s" % (function_name, 1)
                 self.selections[aggregate_selection_name] = expr
                 return aggregate_selection_name
-            elif function_name in ["any", "all", "len"]:
+            elif function_name in ["any", "all", "len", "flatten"]:
                 ## Sqlite functions
                 function_map = {
                     "any": "ANY_IN_GROUP",
                     "all": "ALL_IN_GROUP",
                     "len": "length",
+                    "flatten": "FLATTEN",
                 }
                 sargs = ", ".join([str(arg) for arg in args])
                 expr = "{function_name}({sargs})".format(

--- a/backend/kangas/server/queries.py
+++ b/backend/kangas/server/queries.py
@@ -66,7 +66,7 @@ try:
             "_getitem_": RestrictedPython.Eval.default_guarded_getitem,
             "_getiter_": RestrictedPython.Eval.default_guarded_getiter,
             "_iter_unpack_sequence_": RestrictedPython.Guards.guarded_iter_unpack_sequence,
-            '__name__': 'restricted namespace',
+            "__name__": "restricted namespace",
             "__builtins__": safe_builtins(),
         }
         env.update(kwargs)
@@ -195,21 +195,30 @@ class StdevFunc:
 
 
 def FLATTEN(lists):
-    return str([item for sublist in ast.literal_eval(lists) for item in sublist])
+    if lists:
+        return str([item for sublist in ast.literal_eval(lists) for item in sublist])
+
+    return "[]"
+
 
 def ANY_IN_GROUP(group):
-    group_decoded = [x for x in ast.literal_eval(group)]
-    return any(group_decoded)
+    if group:
+        group_decoded = [x for x in ast.literal_eval(group)]
+        return any(group_decoded)
+
+    return False
+
 
 def ALL_IN_GROUP(group):
     ## This varies from Python semantics: if you are looking for all
     ## then it doesn't make sense to return True if the list
     ## is empty
-    group_decoded = [x for x in ast.literal_eval(group)]
-    if group_decoded:
-        return all(group_decoded)
-    else:
-        return False
+    if group:
+        group_decoded = [x for x in ast.literal_eval(group)]
+        if group_decoded:
+            return all(group_decoded)
+
+    return False
 
 
 def process_results(value):

--- a/backend/kangas/server/queries.py
+++ b/backend/kangas/server/queries.py
@@ -121,11 +121,14 @@ def ANY_IN_GROUP(group):
 
 
 def ALL_IN_GROUP(group):
+    ## This varies from Python semantics: if you are looking for all
+    ## then it doesn't make sense to return True if the list
+    ## is empty
     group = group[1:-1]
     if group:
         return all((False if x == "0" else True) for x in group.split(","))
     else:
-        return True
+        return False
 
 
 def json_extract(json_obj, path):

--- a/backend/kangas/server/queries.py
+++ b/backend/kangas/server/queries.py
@@ -21,7 +21,6 @@ import sqlite3
 import time
 from collections import Counter
 
-import jmespath
 import numpy as np
 from PIL import Image
 

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -48,7 +48,6 @@ setup_args = dict(
     long_description_content_type="text/markdown",
     install_requires=[
         "astor",
-        "jmespath",
         "numpy",
         "tornado",
         "matplotlib",

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -47,6 +47,8 @@ setup_args = dict(
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=[
+        "astor",
+        "jmespath",
         "numpy",
         "tornado",
         "matplotlib",


### PR DESCRIPTION
This PR extends the query language to allow accessing JSON array values. Requires any() or all() for filter.

Examples:

* `any([x["label"] == 'dog' for x in {"Image"}.overlays])` - images with dogs
* `all([x["label"] == 'person' for x in {"Image"}.overlays])` - images with only people (no other labels)
* `any([x["label"] in ["car", "bicycle"] for x in {"Image"}.overlays])` - images with cars or bicycles
* `any([x["label"] == "cat" or x["label"] == "dog" for x in {"Image"}.overlays])` - images with dogs or cats
* `any([x["label"] == "cat" for x in {"Image"}.overlays]) and any([x["label"] == "dog" for x in {"Image"}.overlays])` - images with dogs and cats
* `any([x["score"]  > 0.999 for x in {"Image"}.overlays])` - images with an annotation score greater than 0.999