### PR TITLE
Allow filter to be passed in on URL

### DIFF
--- a/frontend/components/SettingsBar/FilterExpr.client.js
+++ b/frontend/components/SettingsBar/FilterExpr.client.js
@@ -1,5 +1,4 @@
 import { unstable_useRefreshRoot as useRefreshRoot } from 'next/streaming';
-//import TextField from '@mui/material/TextField';
 import Autocomplete from './ReactAutocomplete';
 import { TextField } from '@mui/material';
 import InputAdornment from '@mui/material/InputAdornment';
@@ -17,33 +16,29 @@ const HelpButton = () => (
 const FilterExpr = ({ query, columns }) => {
     const refresh = useRefreshRoot();
 
-    const onKeyPress = useCallback(
-	(e) => {
-	    if (e.key === 'Enter') {
-		refresh({
-                    query: {
-			...query,
-			whereExpr: filter?.value,
-			offset: 0,
-                    },
-		});
-	    }
-	}, [query]
-    );
-
-    const applyFilter = useCallback(
-        (e) => {
-            const filter = document.getElementById('filter');
-            refresh({
+    const onKeyPress = (e) => {
+        const filter = document.getElementById('filter');
+	if (e.key === 'Enter') {
+	    refresh({
                 query: {
-                    ...query,
-                    whereExpr: filter?.value,
-                    offset: 0,
+		    ...query,
+		    whereExpr: filter?.value,
+		    offset: 0,
                 },
-            });
-        },
-        [query]
-    );
+	    });
+	}
+    };
+
+    const applyFilter = (e) => {
+        const filter = document.getElementById('filter');
+        refresh({
+            query: {
+                ...query,
+                whereExpr: filter?.value,
+                offset: 0,
+            },
+        });
+    };
 
     useEffect(() => {
         const filter = document.getElementById('filter');
@@ -53,13 +48,13 @@ const FilterExpr = ({ query, columns }) => {
     return (
         <>
             <Autocomplete
+                defaultValue={query?.whereExpr || ''}
                 trigger={["{"]} 
                 options={{"{": columns.map(name => `"${name}"`)}}
                 changeOnSelect={(trigger, slug) => `{${slug}}`}
                 matchAny={true}
                 regex={'^[a-zA-Z0-9_\\-\\"\\ ]+$'}
-                Component='textarea'
-                spacer={' '}
+                spacer={''}
                 maxOptions={0}
                 spaceRemovers={['.']}
                 placeholder={`e.g.: {"column name"} > 0.5`}

--- a/frontend/components/SettingsBar/ReactAutocomplete.js
+++ b/frontend/components/SettingsBar/ReactAutocomplete.js
@@ -494,7 +494,7 @@ class AutocompleteTextField extends React.Component {
 
     if (typeof value !== 'undefined' && value !== null) {
       val = value;
-    } else if (stateValue) {
+    } else if (stateValue !== null) {
       val = stateValue;
     } else if (defaultValue) {
       val = defaultValue;


### PR DESCRIPTION
This PR does a few things:

* fixes the filter UI to only update when the filter changes (no need to use onCallback). The query is its own state
* sets the default value to be the query.filter
* fixes a bug in the ReactAutoComplete to allow setting the value to nothing (to clear the filter)