### PR TITLE
Add /datagrid/query-page and /datagrid/query-total endpoints

### DIFF
--- a/backend/tests/unit/test_computed_columns.py
+++ b/backend/tests/unit/test_computed_columns.py
@@ -13,7 +13,7 @@
 
 from kangas import DataGrid, Image
 from kangas.server.computed_columns import eval_computed_columns, update_state
-from kangas.server.queries import select_query
+from kangas.server.queries import select_query_count, select_query_page
 
 from ..testlib import AlwaysEquals
 
@@ -33,7 +33,7 @@ dg.save()
 
 
 def select_by_query(where_expr, computed_columns):
-    return select_query(
+    return select_query_page(
         DGID,
         offset=0,
         group_by=None,
@@ -42,6 +42,14 @@ def select_by_query(where_expr, computed_columns):
         where=None,
         limit=100,
         select_columns=None,
+        computed_columns=computed_columns,
+        where_expr=where_expr,
+    )
+
+
+def select_by_query_count(where_expr, computed_columns):
+    return select_query_count(
+        DGID,
         computed_columns=computed_columns,
         where_expr=where_expr,
     )
@@ -96,9 +104,9 @@ def test_none():
         "ncols": 6,
         "nrows": 0,
         "rows": [],
-        "total": 0,
     }
     assert results == expected_results
+    assert 0 == select_by_query_count(where_expr, computed_columns)
 
 
 def test_simple_1():
@@ -190,9 +198,9 @@ def test_simple_1():
                 "row-id": 3,
             },
         ],
-        "total": 3,
     }
     assert results == expected_results
+    assert 3 == select_by_query_count(where_expr, computed_columns)
 
 
 def test_simple_2():
@@ -235,9 +243,9 @@ def test_simple_2():
         "ncols": 7,
         "nrows": 0,
         "rows": [],
-        "total": 0,
     }
     assert results == expected_results
+    assert 0 == select_by_query_count(where_expr, computed_columns)
 
 
 def test_aggregate_where1():
@@ -282,9 +290,9 @@ def test_aggregate_where1():
         "ncols": 7,
         "nrows": 0,
         "rows": [],
-        "total": 0,
     }
     assert results == expected_results
+    assert 0 == select_by_query_count(where_expr, computed_columns)
 
 
 def test_aggregate_column():
@@ -350,9 +358,9 @@ def test_aggregate_column():
                 "row-id": 1,
             }
         ],
-        "total": 1,
     }
     assert results == expected_results
+    assert 1 == select_by_query_count(where_expr, computed_columns)
 
 
 def test_image_column():
@@ -438,9 +446,9 @@ def test_image_column():
                 "row-id": 3,
             },
         ],
-        "total": 3,
     }
     assert results == expected_results
+    assert 3 == select_by_query_count(where_expr, computed_columns)
 
 
 def test_image_column_metadata():
@@ -481,9 +489,9 @@ def test_image_column_metadata():
         "ncols": 6,
         "nrows": 0,
         "rows": [],
-        "total": 0,
     }
     assert results == expected_results
+    assert 0 == select_by_query_count(where_expr, computed_columns)
 
 
 def test_image_computed_column():
@@ -533,9 +541,9 @@ def test_image_computed_column():
         "ncols": 7,
         "nrows": 0,
         "rows": [],
-        "total": 0,
     }
     assert results == expected_results
+    assert 0 == select_by_query_count(where_expr, computed_columns)
 
 
 def test_shortcut_boolean_logic():


### PR DESCRIPTION
This PR breaks out the SQL total from the paged query.

At some point, we can deprecate /datagrid/query