### PR TITLE
Add example for using DataGrid with the HF Hub

### DIFF
--- a/examples/hugging_face/datagrids_with_hub/README.md
+++ b/examples/hugging_face/datagrids_with_hub/README.md
@@ -115,3 +115,19 @@ Or run the snippet from a Colab notebook in the following way
 
 https://user-images.githubusercontent.com/7529846/206373126-829e56b7-a340-4300-ac23-1eca7f1768bc.mp4
 
+## Using DataGrid with Existing Hugging Face Datasets
+
+If you already have a dataset hosted on the Hub, Kangas also supports directly loading the dataset for analysis from the CLI.
+
+```
+kangas server <dataset name> --split "val"
+```
+
+For example to load the `test` set of the `imdb` dataset, you would run
+
+```
+kangas server imdb --split "test"
+```
+
+This command will automatically download the dataset from the hub and start the Kangas UI with the dataset loaded into it.
+

--- a/examples/hugging_face/datagrids_with_hub/README.md
+++ b/examples/hugging_face/datagrids_with_hub/README.md
@@ -131,3 +131,4 @@ kangas server imdb --split "test"
 
 This command will automatically download the dataset from the hub and start the Kangas UI with the dataset loaded into it.
 
+https://user-images.githubusercontent.com/7529846/207111507-0671cbb5-e3b7-4e79-905b-b3032f25b0f9.mp4

--- a/examples/hugging_face/datagrids_with_hub/README.md
+++ b/examples/hugging_face/datagrids_with_hub/README.md
@@ -68,6 +68,7 @@ python upload_to_hub.py --repo_id <Your Repo ID> \
 --path <Path to the datagrid file> \
 --path_in_repo <The path for your datagrid in the dataset repo>
 ```
+<img width="600" alt="datagrid-hf-hub-example" src="https://user-images.githubusercontent.com/7529846/206374126-82fb60ab-dd68-4739-8655-153ad02930b7.png">
 
 ## Load your DataGrids from the Hub
 
@@ -112,4 +113,5 @@ python download_from_hub.py --repo_id <Your Repo ID> \
 
 Or run the snippet from a Colab notebook in the following way
 
+https://user-images.githubusercontent.com/7529846/206373126-829e56b7-a340-4300-ac23-1eca7f1768bc.mp4
 

--- a/examples/hugging_face/datagrids_with_hub/README.md
+++ b/examples/hugging_face/datagrids_with_hub/README.md
@@ -1,0 +1,115 @@
+# Using DataGrids with the Hugging Face Hub
+
+In this guide we will demonstrate how to use the Hugging Face Hub as a way to store your Kangas datagrids.
+
+For this example, we will use the OpenAI's CLIP model on the CIFAR10 dataset. Once we run our evaluation, we will upload the resulting datagrid file to the Hub as a dataset. We will then demonstrate how you can load your datagrids directly from the Hub.
+
+This workflow is a convenient way to save evaluations from your model across multiple datasets and have them accessible in a single location. Saving your datagrids to the Hub lets you share and access your model evaluations from any machine.
+
+## Install Dependencies
+
+```shell
+pip install -r requirements.txt
+```
+
+## Login to the Hugging Face Hub
+
+In order to run this example, you will need to log in to the Hub using your personal access token. [You can find that here](https://huggingface.co/settings/tokens)
+
+```shell
+huggingface-cli login
+```
+
+## Run the prediction script
+
+Our prediction script will download the CIFAR10 test set, evaluate each sample in the dataset using the CLIP model and save the image, label, predicted label and model confidence scores to a datagrid file.
+
+```shell
+python predict.py
+```
+
+Running this script will produce a `cifar10-test.datagrid` file in the current working directory.
+
+## Run the Upload Script
+
+Next, we'll upload our datagrid to the Hugging Face Hub using this snippet in the `upload_to_hub.py` script.
+
+```python
+import argparse
+
+from huggingface_hub import HfApi
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo_id")
+    parser.add_argument("--path")
+    parser.add_argument("--path_in_repo")
+
+    return parser.parse_args()
+
+
+args = get_args()
+
+api = HfApi()
+api.upload_file(
+    path_or_fileobj=args.path,
+    path_in_repo=args.path_in_repo,
+    repo_id=args.repo_id,
+    repo_type="dataset",
+)
+
+```
+
+The upload script assumes that you have already created a dataset repository on the Hub to store your model evaluations.
+
+```shell
+python upload_to_hub.py --repo_id <Your Repo ID> \
+--path <Path to the datagrid file> \
+--path_in_repo <The path for your datagrid in the dataset repo>
+```
+
+## Load your DataGrids from the Hub
+
+The following snippet will load in your datagrid directly from the Hub. Simply pass in `repo_id` and `filename` of the datagrid file you want to analyze.
+
+```python
+import argparse
+
+from huggingface_hub import hf_hub_download
+
+from kangas import DataGrid
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo_id")
+    parser.add_argument("--filename")
+    parser.add_argument("--port", type=int, default=4000)
+
+    return parser.parse_args()
+
+
+args = get_args()
+
+dg = DataGrid.read_datagrid(
+    hf_hub_download(
+        repo_id=args.repo_id,
+        filename=args.filename,
+        repo_type="dataset",
+        use_auth_token=True,
+    )
+)
+dg.show(port=args.port)
+```
+
+You can run this snippet using the `download_from_hub.py` script.
+
+```shell
+python download_from_hub.py --repo_id <Your Repo ID> \
+--filename <Name of your datagrid file>
+```
+
+Or run the snippet from a Colab notebook in the following way
+
+

--- a/examples/hugging_face/datagrids_with_hub/download_from_hub.py
+++ b/examples/hugging_face/datagrids_with_hub/download_from_hub.py
@@ -9,6 +9,7 @@ def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo_id")
     parser.add_argument("--filename")
+    parser.add_argument("--port", type=int, default=4000)
 
     return parser.parse_args()
 
@@ -23,4 +24,4 @@ dg = DataGrid.read_datagrid(
         use_auth_token=True,
     )
 )
-dg.show(port=8892)
+dg.show(port=args.port)

--- a/examples/hugging_face/datagrids_with_hub/download_from_hub.py
+++ b/examples/hugging_face/datagrids_with_hub/download_from_hub.py
@@ -1,0 +1,26 @@
+import argparse
+
+from huggingface_hub import hf_hub_download
+
+from kangas import DataGrid
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo_id")
+    parser.add_argument("--filename")
+
+    return parser.parse_args()
+
+
+args = get_args()
+
+dg = DataGrid.read_datagrid(
+    hf_hub_download(
+        repo_id=args.repo_id,
+        filename=args.filename,
+        repo_type="dataset",
+        use_auth_token=True,
+    )
+)
+dg.show(port=8892)

--- a/examples/hugging_face/datagrids_with_hub/predict.py
+++ b/examples/hugging_face/datagrids_with_hub/predict.py
@@ -18,7 +18,7 @@ columns = ["id", "image", "label", "predicted_label"]
 columns.extend([f"score_{label_name}" for label_name in label_names])
 
 dg = DataGrid(
-    name="cifar10-test.datagrid",
+    name="cifar10-test",
     columns=columns,
 )
 
@@ -49,7 +49,7 @@ for idx, example in enumerate(tqdm(dataset, total=num_examples)):
         label_name,
         predicted_label_name,
     ]
-    row + list(probs)
+    row.extend(probs.tolist()[0])
     dg.append(row)
 
 dg.save()

--- a/examples/hugging_face/datagrids_with_hub/predict.py
+++ b/examples/hugging_face/datagrids_with_hub/predict.py
@@ -1,0 +1,55 @@
+from datasets import load_dataset
+from tqdm import tqdm
+from transformers import CLIPModel, CLIPProcessor
+
+from kangas import DataGrid, Image
+
+SPLIT = "test"
+dataset = load_dataset("cifar10", split=SPLIT, streaming=True)
+dataset = dataset.shuffle(seed=42)
+num_examples = dataset.info.splits[SPLIT].num_examples
+
+label_names = dataset.features["label"].names
+
+model = CLIPModel.from_pretrained("openai/clip-vit-base-patch32")
+processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
+
+columns = ["id", "image", "label", "predicted_label"]
+columns.extend([f"score_{label_name}" for label_name in label_names])
+
+dg = DataGrid(
+    name="cifar10-test.datagrid",
+    columns=columns,
+)
+
+for idx, example in enumerate(tqdm(dataset, total=num_examples)):
+    image = example["img"]
+    label = example["label"]
+
+    inputs = processor(
+        text=label_names,
+        images=image,
+        return_tensors="pt",
+        padding=True,
+    )
+    outputs = model(**inputs)
+    logits_per_image = (
+        outputs.logits_per_image
+    )  # this is the image-text similarity score
+    probs = logits_per_image.softmax(
+        dim=1
+    )  # we can take the softmax to get the label probabilities
+
+    label_name = label_names[label]
+    predicted_label_name = label_names[probs.argmax()]
+
+    row = [
+        idx,
+        Image(image),
+        label_name,
+        predicted_label_name,
+    ]
+    row + list(probs)
+    dg.append(row)
+
+dg.save()

--- a/examples/hugging_face/datagrids_with_hub/requirements.txt
+++ b/examples/hugging_face/datagrids_with_hub/requirements.txt
@@ -1,0 +1,4 @@
+transformers
+kangas
+datasets
+huggingface_hub

--- a/examples/hugging_face/datagrids_with_hub/upload_to_hub.py
+++ b/examples/hugging_face/datagrids_with_hub/upload_to_hub.py
@@ -1,0 +1,23 @@
+import argparse
+
+from huggingface_hub import HfApi
+
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo_id")
+    parser.add_argument("--path")
+    parser.add_argument("--path_in_repo")
+
+    return parser.parse_args()
+
+
+args = get_args()
+
+api = HfApi()
+api.upload_file(
+    path_or_fileobj=args.path,
+    path_in_repo=args.path_in_repo,
+    repo_id=args.repo_id,
+    repo_type="dataset",
+)

--- a/notebooks/Using_Kangas_Datagrids_with_the_Hugging_Face_Hub.ipynb
+++ b/notebooks/Using_Kangas_Datagrids_with_the_Hugging_Face_Hub.ipynb
@@ -1,0 +1,101 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Install Dependencies"
+      ],
+      "metadata": {
+        "id": "zUEAwMYFRTxt"
+      }
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "KaHN1umeQlRS"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install huggingface_hub kangas --quiet"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Login to Hugging Face Hub"
+      ],
+      "metadata": {
+        "id": "vudG7iCnRWaP"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from huggingface_hub import login\n",
+        "login()"
+      ],
+      "metadata": {
+        "id": "WMb6nVe_QoNt"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "# Download Datagrid from Hub"
+      ],
+      "metadata": {
+        "id": "Il77akajRYhl"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from huggingface_hub import hf_hub_download\n",
+        "\n",
+        "from kangas import DataGrid\n",
+        "\n",
+        "\n",
+        "dg = DataGrid.read_datagrid(\n",
+        "    hf_hub_download(\n",
+        "        repo_id=\"Comet/CLIP-eval\",\n",
+        "        filename=\"cifar10-test.datagrid\",\n",
+        "        repo_type=\"dataset\",\n",
+        "        use_auth_token=True,\n",
+        "    )\n",
+        ")\n",
+        "dg.show()"
+      ],
+      "metadata": {
+        "id": "Bq-jJ7Q4Q3zk"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [],
+      "metadata": {
+        "id": "lvXY-XRZRDzI"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}

--- a/notebooks/Using_Kangas_Datagrids_with_the_Hugging_Face_Hub.ipynb
+++ b/notebooks/Using_Kangas_Datagrids_with_the_Hugging_Face_Hub.ipynb
@@ -95,6 +95,7 @@
         "        repo_id=\"Comet/CLIP-eval\",\n",
         "        filename=\"cifar10-test.datagrid\",\n",
         "        repo_type=\"dataset\",\n",
+        "        use_auth_token=True\n",
         "    )\n",
         ")\n",
         "dg.show()"

--- a/notebooks/Using_Kangas_Datagrids_with_the_Hugging_Face_Hub.ipynb
+++ b/notebooks/Using_Kangas_Datagrids_with_the_Hugging_Face_Hub.ipynb
@@ -17,6 +17,15 @@
     {
       "cell_type": "markdown",
       "source": [
+        "In this guide we will demonstrate how to download Kangas DataGrids directly from a Hugging Face Hub dataset repository. \n"
+      ],
+      "metadata": {
+        "id": "HnTxrwK9x_HT"
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
         "# Install Dependencies"
       ],
       "metadata": {
@@ -37,7 +46,7 @@
     {
       "cell_type": "markdown",
       "source": [
-        "# Login to Hugging Face Hub"
+        "# Login to the Hugging Face Hub"
       ],
       "metadata": {
         "id": "vudG7iCnRWaP"
@@ -65,6 +74,15 @@
       }
     },
     {
+      "cell_type": "markdown",
+      "source": [
+        "We will use `hf_hub_download` to fetch a saved datagrid file [that's been saved on the hub](https://huggingface.co/datasets/Comet/CLIP-eval/tree/main). "
+      ],
+      "metadata": {
+        "id": "G-8y3TsczSVJ"
+      }
+    },
+    {
       "cell_type": "code",
       "source": [
         "from huggingface_hub import hf_hub_download\n",
@@ -77,7 +95,6 @@
         "        repo_id=\"Comet/CLIP-eval\",\n",
         "        filename=\"cifar10-test.datagrid\",\n",
         "        repo_type=\"dataset\",\n",
-        "        use_auth_token=True,\n",
         "    )\n",
         ")\n",
         "dg.show()"


### PR DESCRIPTION
This PR:

1. Adds example scripts and a README to demonstrate how to upload and download datagrids to the Hugging Face Hub.
2. Adds an example Notebook to demonstrate how to download datagrids directly from the Hub. 
 