### PR TITLE
Set fixed min-height in select modal body

### DIFF
--- a/frontend/app/modals/SelectColumnDrowpdown/SelectColumnDropdown.module.scss
+++ b/frontend/app/modals/SelectColumnDrowpdown/SelectColumnDropdown.module.scss
@@ -51,6 +51,7 @@
     width: 100%;
     display: block;
     align-items: center;
+    min-height: 350px;
 }
 
 .react-select-container {
@@ -65,7 +66,7 @@
     display: flex;
     justify-content: flex-end;
     margin: 20px 0px;
-    
+
     div {
         margin-right: 12px;
     }


### PR DESCRIPTION
After this tweak, modal looks like:

![Screenshot from 2023-01-30 12-15-42](https://user-images.githubusercontent.com/168568/215586835-4596441c-7926-4ee9-86c9-2bb30c83073a.png)
![Screenshot from 2023-01-30 12-15-52](https://user-images.githubusercontent.com/168568/215586852-dc545583-56f5-4926-abec-14a682d58750.png)

rather than there not being room.