### PR TITLE
Add line-height to see wavy line

### DIFF
--- a/frontend/app/Settings/ReactAutoComplete.js
+++ b/frontend/app/Settings/ReactAutoComplete.js
@@ -531,6 +531,7 @@ class AutocompleteTextField extends React.Component {
             sx: {
                 fontSize: '13px',
                 width: '360px',
+                lineHeight: '1.5',
             },
           }}
           inputProps={{


### PR DESCRIPTION
Adds some line-height so you can see the wavy line.

Before:
![Screenshot from 2023-02-01 20-02-11](https://user-images.githubusercontent.com/168568/216228785-bf549451-6431-46f0-9808-cb4c41dd10da.png)


After:
![Screenshot from 2023-02-01 19-59-26](https://user-images.githubusercontent.com/168568/216228516-8e70f6b6-7df5-4773-b6d8-fd409b3d2e73.png)
