### PR TITLE
 Draw labels with correct scale 

### DIFF
--- a/frontend/app/DeferredComponent.js
+++ b/frontend/app/DeferredComponent.js
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { CircularProgress } from "@material-ui/core";
 import { useInView } from "react-intersection-observer";
 
-const Deferred = ({ children }) => {
+const Deferred = ({ fallbackProps={}, children }) => {
   const [hasRendered, setHasRendered] = useState(false)
   const { ref, inView, entry } = useInView({
       threshold: 0,
@@ -16,9 +16,10 @@ const Deferred = ({ children }) => {
     }
   }, [inView, hasRendered]);
 
+
       return (
         <div ref={ref}>
-          { !hasRendered && <CircularProgress /> }
+          { !hasRendered && <div {...fallbackProps}> <CircularProgress /> </div> }
           { hasRendered && children }
         </div>
       )

--- a/frontend/app/cells/image/ImageCanvas/ImageCanvas.module.scss
+++ b/frontend/app/cells/image/ImageCanvas/ImageCanvas.module.scss
@@ -39,13 +39,16 @@
         position: absolute;
         left: 0;
         border-radius: 10px;
-        max-width: 100%;
 
         &.canvas {
             z-index: 999;
 
             &.vertical {
                 height: 400px;
+            }
+
+            &.horizontal {
+                width: 400px;
             }
 
         }
@@ -57,12 +60,18 @@
                 height: 400px;
             }
 
-	    &.pixelated {
-		image-rendering: pixelated;
-	    }
-	    &.grayscale {
-		filter: grayscale(1);
-	    }
+            &.horizontal {
+                width: 400px;
+            }
+
+            &.pixelated {
+                image-rendering: pixelated;
+            }
+
+            &.grayscale {
+                filter: grayscale(1);
+            }
+
         }
     }
 

--- a/frontend/app/cells/image/ImageCanvas/ImageCanvas.module.scss
+++ b/frontend/app/cells/image/ImageCanvas/ImageCanvas.module.scss
@@ -28,12 +28,14 @@
 
 .canvas-container {
     position: relative;
-    width: 400px;
-    height: 300px;
 
-    &.vertical {
-        height: 400px;
+    &.grouped {
+        max-width: 400px;
+        max-height: 400px;
+        padding-top: 2px;
+        padding-bottom: 2px;
     }
+
 
     .output {
         position: absolute;
@@ -43,26 +45,11 @@
         &.canvas {
             z-index: 999;
 
-            &.vertical {
-                height: 400px;
-            }
-
-            &.horizontal {
-                width: 400px;
-            }
-
         }
 
         &.image {
             z-index: 998;
 
-            &.vertical {
-                height: 400px;
-            }
-
-            &.horizontal {
-                width: 400px;
-            }
 
             &.pixelated {
                 image-rendering: pixelated;
@@ -75,6 +62,30 @@
         }
     }
 
+}
+
+.vertical {
+    height: 400px;
+
+    &.single {
+        min-height: 400px;
+        height: unset;
+    }
+}
+
+.horizontal {
+    width: 400px;
+
+    &.single {
+        min-height: 400px;
+        width: unset;
+    }
+
+}
+
+.single {
+    max-width: unset;
+    max-height: unset;
 }
 
 .slider-container {
@@ -143,5 +154,11 @@
 .checkbox-container {
     display: flex;
     justify-content: space-between;
+}
+
+.output-container {
+    width: 100%;
+    display: flex;
+    justify-content: center;
 }
 

--- a/frontend/app/cells/image/ImageCanvas/ImageCanvasCell.js
+++ b/frontend/app/cells/image/ImageCanvas/ImageCanvasCell.js
@@ -67,13 +67,17 @@ const ImageCanvasCell = async ({ assets, query }) => {
                 <ImageCanvasControls />
                 <div className={cx('canvas-column')}>
                     { isGroup ? assets?.map(id => (
-                      <Deferred>
-                          <DialogueModal fullScreen={false} toggleElement={
-                            <ImageCanvasOutput dgid={dgid} timestamp={timestamp} assetId={id} />
-                          } >
-                              <ImageCanvasCellStandAlone dgid={dgid} timestamp={timestamp} assetId={id} />
-                          </DialogueModal>
-                      </Deferred>
+                        <Deferred fallbackProps={{ style: { height: '400px' }}}>
+                            <DialogueModal fullScreen={false} toggleElement={
+                                <ImageCanvasOutput dgid={dgid} timestamp={timestamp} assetId={id} />
+                            } >
+                                
+                                <Suspense fallback={<>Loading</>}>
+                                    <ImageCanvasCellStandAlone dgid={dgid} timestamp={timestamp} assetId={id} />
+                                </Suspense>
+                                
+                            </DialogueModal>
+                        </Deferred>
                     ) ) : (
                       <Deferred>
                           <ImageCanvasOutput dgid={dgid} timestamp={timestamp} assetId={assets[0]} />

--- a/frontend/app/cells/image/ImageCanvas/Output.js
+++ b/frontend/app/cells/image/ImageCanvas/Output.js
@@ -1,6 +1,10 @@
 import ImageCanvasOutputClient from "./OutputClient"
 import fetchAsset from "../../../../lib/fetchAsset"
 import fetchAssetMetadata from "../../../../lib/fetchAssetMetadata";
+import styles from './ImageCanvas.module.scss';
+import classNames from 'classnames/bind';
+import Deferred from "../../../DeferredComponent";
+const cx = classNames.bind(styles);
 
 
 const ImageCanvasOutput = async ({ assetId, dgid, timestamp }) => {
@@ -15,13 +19,15 @@ const ImageCanvasOutput = async ({ assetId, dgid, timestamp }) => {
     //const metadata = await fetchAssetMetadata({ assetId, dgid, timestamp });
 
     return (
-        <div>
-            <ImageCanvasOutputClient 
-                assetId={assetId} 
-                timestamp={timestamp}
-                dgid={dgid}
-                imageSrc={`/api/image?${querystring}`}
-            />
+        <div className={cx('output-container')}>
+            <Deferred>
+                <ImageCanvasOutputClient 
+                    assetId={assetId} 
+                    timestamp={timestamp}
+                    dgid={dgid}
+                    imageSrc={`/api/image?${querystring}`}
+                />
+            </Deferred>
         </div>
     )
 

--- a/frontend/app/prefetch.js
+++ b/frontend/app/prefetch.js
@@ -12,6 +12,7 @@ const Prefetch = async ({ datagrids, query }) => {
             try {
                 const temp = await fetchDataGrid({ dgid: dgid.value, timestamp: dgid.timestamp, limit });
             } catch (error) {
+                console.log('here it is')
                 console.log(error);
             }
         }

--- a/frontend/lib/fetchDatagrid.js
+++ b/frontend/lib/fetchDatagrid.js
@@ -28,8 +28,7 @@ const fetchDataGrid = async (query, url=config.apiUrl) => {
             displayColumns
         }
     } catch (error) {
-        console.log(error);
-        console.log("NOOOOOOO")
+        //console.log(error);
     }
 };
 


### PR DESCRIPTION
Occasionally, specific images will be drawn with mis-scaled labels when in grouped view. The issue is stems from the fact that images of certain dimensions will resize multiple times, and our resize-redraw loop had some nondeterministic execution order.

This breaks apart the steps of the resize-redraw loop to better control order. There seems to be some performance ding, which I'll be addressing in a separate issue next.