### PR TITLE
Better lazy loading of histograms/categories

### DIFF
--- a/frontend/app/cells/boolean/GroupedBooleanCell.js
+++ b/frontend/app/cells/boolean/GroupedBooleanCell.js
@@ -7,13 +7,13 @@ import styles from '../Cell.module.scss';
 
 const cx = classNames.bind(styles);
 
-const GroupedBooleanCell = ({ value, expanded = false }) => {
+const GroupedBooleanCell = ({ value, expanded = false, ssr = false }) => {
     const primitive = isPrimitive(value);
 
     return (
         <div className={cx(['cell', 'group', 'cell-content'], { expanded })}>
             { primitive && formatValue(value)}
-            { !primitive && <Suspense fallback={<>Loading</>}><Category value={value} expanded={expanded} /></Suspense>}
+            { !primitive && <Suspense fallback={<>Loading</>}><Category value={value} expanded={expanded} ssr={ssr} /></Suspense>}
         </div>
     );
 }

--- a/frontend/app/cells/boolean/index.js
+++ b/frontend/app/cells/boolean/index.js
@@ -2,12 +2,12 @@ import Base from './BaseBooleanCell';
 import Grouped from './GroupedBooleanCell';
 import DialogueModal from '../../modals/DialogueModal/DialogueModalClient';
 
-const BooleanCell = ({ value, query, style }) => {
+const BooleanCell = ({ value, query, style, ssr }) => {
     if (!query?.groupBy) return (
         <DialogueModal toggleElement={<Base value={value} query={query}  style={style} />}><Base value={value} query={query} /></DialogueModal>
     );
     else  return (
-        <DialogueModal toggleElement={<Grouped value={value} query={query} />}><Grouped value={value} query={query} expanded={true} /></DialogueModal>
+        <DialogueModal toggleElement={<Grouped value={value} query={query} ssr={ssr} />}><Grouped value={value} query={query} expanded={true} ssr={ssr} /></DialogueModal>
     );
 }
 

--- a/frontend/app/cells/charts/histogram/Histogram.js
+++ b/frontend/app/cells/charts/histogram/Histogram.js
@@ -6,8 +6,8 @@ import styles from '../Charts.module.scss'
 const cx = classNames.bind(styles);
 
 const Histogram = async ({ value, expanded, ssr }) => {
-    const ssrData = ssr ? await fetchHistogram(value, true) : false; 
-   
+    const ssrData = ssr ? await fetchHistogram(value, ssr) : false; 
+    
     return <HistogramClient expanded={expanded} value={value} ssrData={ssrData} />;
     
 }

--- a/frontend/app/cells/date/GroupedDateCell.js
+++ b/frontend/app/cells/date/GroupedDateCell.js
@@ -7,13 +7,13 @@ import styles from '../Cell.module.scss';
 
 const cx = classNames.bind(styles);
 
-const GroupedDateCell = ({ value, expanded = false }) => {
+const GroupedDateCell = ({ value, expanded = false, ssr = false }) => {
     const primitive = isPrimitive(value);
 
     return (
         <div className={cx(['cell', 'group', 'cell-content'], { expanded })}>
             { primitive && formatValue(value)}
-            { !primitive && <Suspense fallback={<>Loading</>}><Histogram value={value} expanded={expanded} /></Suspense>}
+            { !primitive && <Suspense fallback={<>Loading</>}><Histogram value={value} expanded={expanded} ssr={ssr} /></Suspense>}
         </div>
     );
 }

--- a/frontend/app/cells/date/index.js
+++ b/frontend/app/cells/date/index.js
@@ -2,12 +2,12 @@ import Base from './BaseDateCell';
 import Grouped from './GroupedDateCell';
 import DialogueModal from '../../modals/DialogueModal/DialogueModalClient';
 
-const DateCell = ({ value, query, style }) => {
+const DateCell = ({ value, query, style, ssr }) => {
     if (!query?.groupBy) return (
         <DialogueModal toggleElement={<Base value={value} query={query}  style={style} />}><Base value={value} query={query} /></DialogueModal>
     );
     else  return (
-        <DialogueModal toggleElement={<Grouped value={value} query={query} />}><Grouped value={value} query={query} expanded={true} /></DialogueModal>
+        <DialogueModal toggleElement={<Grouped value={value} query={query} ssr={ssr} />}><Grouped value={value} query={query} expanded={true} ssr={ssr} /></DialogueModal>
     );
 }
 

--- a/frontend/app/cells/float/GroupedFloatCell.js
+++ b/frontend/app/cells/float/GroupedFloatCell.js
@@ -7,12 +7,12 @@ import styles from '../Cell.module.scss'
 
 const cx = classNames.bind(styles);
 
-const GroupedFloatCell = ({ value, expanded = false}) => {
+const GroupedFloatCell = ({ value, expanded = false, ssr=false}) => {
     const primitive = isPrimitive(value);
     return (
         <div className={cx(['cell', 'group', 'cell-content'], { expanded })}>
             { primitive && formatValue(value)}
-            { !primitive && <Suspense fallback={<>Loading</>}><Histogram value={value} expanded={expanded} /></Suspense>}
+            { !primitive && <Suspense fallback={<>Loading</>}><Histogram value={value} expanded={expanded} ssr={ssr} /></Suspense>}
         </div>
     );
 }

--- a/frontend/app/cells/float/index.js
+++ b/frontend/app/cells/float/index.js
@@ -3,14 +3,14 @@ import DialogueModal from "../../modals/DialogueModal/DialogueModalClient";
 import Base from "./BaseFloatCell";
 import Grouped from './GroupedFloatCell'
 
-const FloatCell = ({ value, query, style }) => {
+const FloatCell = ({ value, query, style, ssr }) => {
     if (!query?.groupBy) return (
         <DialogueModal toggleElement={<Base value={value} query={query} style={style} />}><Base value={value} query={query} /></DialogueModal>
     );
     else return (
-        <DialogueModal toggleElement={<Suspense fallback={<>FD</>}><Grouped value={value} query={query} /></Suspense>}>
+        <DialogueModal toggleElement={<Suspense fallback={<>FD</>}><Grouped value={value} query={query} ssr={ssr} /></Suspense>}>
             <Suspense fallback={<>Loading</>}>
-                <Grouped value={value} query={query} expanded={true} />
+                <Grouped value={value} query={query} expanded={true} ssr={ssr} />
             </Suspense>
             
         </DialogueModal>

--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -11,6 +11,7 @@ import fetchTimestamp from '../lib/fetchTimestamp';
 import EMPTY from '../lib/consts/emptyTable';
 import Prefetch from './prefetch';
 import Skeleton from './Skeleton';
+import Imports from './perf/Imports';
 
 const Main = async ({ query }) => {
     const data = await fetchDataGrid(query);
@@ -70,6 +71,7 @@ const Page = async ({ searchParams }) => {
 
     return (
         <div>
+            <Imports />
             <Suspense fallback={<Skeleton message={"Suspending Page"} />}>
                 <Main query={query} />
             </Suspense>

--- a/frontend/app/perf/Imports.js
+++ b/frontend/app/perf/Imports.js
@@ -1,0 +1,28 @@
+'use client';
+
+// This is an incredibly hacky way to load Plotly early
+import dynamic from 'next/dynamic';
+
+const Plot = dynamic(() => import('react-plotly.js'), {
+    ssr: false,
+});
+
+const Imports = () => (
+    <div style={{ display: 'none' }}>
+        <Plot
+            data={[
+                {
+                    x: [1, 2, 3],
+                    y: [2, 6, 3],
+                    type: 'scatter',
+                    mode: 'lines+markers',
+                    marker: { color: 'red' },
+                },
+                { type: 'bar', x: [1, 2, 3], y: [2, 5, 3] },
+            ]}
+            layout={{ width: 320, height: 240, title: 'A Fancy Plot' }}
+        />
+    </div>
+);
+
+export default Imports;


### PR DESCRIPTION
Currently, our lazy loading is not accurately reflecting what is and isn't in the viewport. This fixes that, rendering the initial columns via SSR and offloading the rest to client fetching, to be fetched as they scroll into view.