### PR TITLE
Revert grouped-cell min width

### DIFF
--- a/frontend/app/cells/Cell.module.scss
+++ b/frontend/app/cells/Cell.module.scss
@@ -19,7 +19,6 @@
 
     &.group {
         min-height: 116px;
-        min-width: 200px;
     }
 
     &.group > img {


### PR DESCRIPTION
Otherwise the header can get smaller than the cell. Why do we need min width?