### PR TITLE
Use multiple annotation layers

### DIFF
--- a/frontend/app/cells/image/ImageCanvas/OutputClient.js
+++ b/frontend/app/cells/image/ImageCanvas/OutputClient.js
@@ -17,7 +17,7 @@ const ImageCanvasOutputClient = ({ assetId, dgid, timestamp, imageSrc }) => {
     const [loaded, setLoaded] = useState(false);
 
     const {
-        annotations,
+	layers,
         score,
         hiddenLabels,
     } = useLabels({ assetId, timestamp, dgid });
@@ -54,18 +54,22 @@ const ImageCanvasOutputClient = ({ assetId, dgid, timestamp, imageSrc }) => {
 
 
     const drawLabels = useCallback(() => {
-        if (annotations?.data) {
+        if (layers) {
             const alpha = 200; // get from slider?
             const ctx = labelCanvas.current.getContext("2d");
             ctx.clearRect(0, 0, imgDims.width, imgDims.height);
             // Display any masks first:
-            for (let annotation of annotations.data) {
-                if (annotation.mask) {
-                    processMask(ctx, annotation, imgDims, hiddenLabels, score, alpha);
-                }
-            }
+	    for (let layer of layers) {
+		for (let annotation of layer?.data) {
+                    if (annotation.mask) {
+			console.log("drawing mask!");
+			processMask(ctx, annotation, imgDims, hiddenLabels, score, alpha);
+                    }
+		}
+	    }
             // Next, draw all other annotations:
-            for (let annotation of annotations.data) {
+	    for (let layer of layers) {
+	     for (let annotation of layer?.data) {
                 if (annotation.score && annotation.score <= score) continue;
                 if (!!annotation.points) {
                     const points = annotation.points;
@@ -140,9 +144,10 @@ const ImageCanvasOutputClient = ({ assetId, dgid, timestamp, imageSrc }) => {
                 } else {
                     console.log(`unknown annotation type: ${annotation}`);
                 }
-            }
+             }
+	    }
         }
-    }, [imageScale, score, hiddenLabels, annotations, imgDims]);
+    }, [imageScale, score, hiddenLabels, layers, imgDims]);
 
 
     const onLoad = useCallback((e) => {

--- a/frontend/lib/hooks/useLabels.js
+++ b/frontend/lib/hooks/useLabels.js
@@ -52,6 +52,7 @@ const useLabels = ({ assetId, dgid, timestamp }) => {
     // TODO Support annotations from multiple groups, not just [0] == '(uncategorized)'
     const image = useMemo(() => images?.[assetId], [assetId, images?.[assetId]]);
     const annotations = useMemo(() => images?.[assetId]?.annotations?.[0], [images?.[assetId]?.annotations?.[0]]);
+    const layers = useMemo(() => images?.[assetId]?.annotations, [images?.[assetId]?.annotations]);
     const dimensions = useMemo(() => ({ ...images?.[assetId]?.image }), [images?.[assetId]?.image])
 
     useEffect(() => {
@@ -64,6 +65,7 @@ const useLabels = ({ assetId, dgid, timestamp }) => {
 
     return {
         annotations,
+	layers,
         scoreRange: {},
         updateScore,
         updateScoreRange,


### PR DESCRIPTION
Although this is currently a bit confusing as it displays multiple layers on top of each other, at least it lets us see the layers. 

Show are two layers (Prediction and Truth, but that isn't shown anywhere) and each layer has a mask for each of barcode and qrcode. 

![Screenshot from 2023-03-20 19-29-57](https://user-images.githubusercontent.com/168568/226505375-74b3554c-e348-49c7-9a7b-5d21ac38eb6a.png)


Soon we'll separate the layers in the UI, given control over each.