### PR TITLE
Prevent unnecessary metadata fetches in grouped view

### DIFF
--- a/frontend/app/cells/image/GroupedImageCell.js
+++ b/frontend/app/cells/image/GroupedImageCell.js
@@ -43,9 +43,12 @@ const ExpandedGroupedCell = async ({ value }) => {
         }
     }
 
+
     return (
         <CanvasProvider value={{ images: imageStore, metadata, isGroup: true }}>
-            <ImageCanvasCell assets={images.values} query={value} />
+            <Suspense fallback={<>Loading</>}>
+                <ImageCanvasCell assets={images?.values} query={value} />
+            </Suspense>
         </CanvasProvider>
     )
 }

--- a/frontend/app/cells/image/ImageCanvas/ExpandedCanvasClientSide.js
+++ b/frontend/app/cells/image/ImageCanvas/ExpandedCanvasClientSide.js
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useMemo, useState } from "react";
+import fetchAssetMetadata from "../../../../lib/fetchAssetMetadata";
+import styles from './ImageCanvas.module.scss';
+import classNames from 'classnames/bind';
+import Deferred from "../../../DeferredComponent";
+import CanvasProvider from "../../../contexts/CanvasContext";
+import ImageCanvasControls from "./Controls";
+import ImageCanvasOutputClient from "./OutputClient";
+
+const cx = classNames.bind(styles);
+
+const ExpandedCanvasClientSide = ({ dgid, timestamp, assetId }) => {
+    const [metadata, setMetadata] = useState({});
+
+    useEffect(() => {
+        fetchAssetMetadata({ dgid, timestamp, assetId, ssr: false })
+            .then(res => {
+                setMetadata(res);
+            })
+    }, [dgid, timestamp, assetId]);
+
+    const querystring = useMemo(() => {
+        const url = new URLSearchParams({ 
+            assetId, 
+            dgid, 
+            timestamp, 
+            endpoint: 'download'
+        }).toString();
+        return url;
+    }, [assetId, dgid, timestamp]);
+
+    const labels = useMemo(() => {
+        const labels = new Set();
+        if (typeof(metadata.annotations) !== 'undefined') {
+            for (const annotation of metadata.annotations) {
+                for (const data of annotation.data) {
+                    if (data.label) {
+                        labels.add(data.label);
+                    }
+		            if (data.labels) {
+                        for (const label of data.labels) {
+                            labels.add(label);
+                        }
+                    }
+                }
+            }
+        }
+        return Array.from(labels);
+    }, [metadata])
+
+    return (
+      <CanvasProvider value={{ images: { [assetId]: { fetchedMeta: false }}, metadata, isGroup: false }}>
+        <div className={cx('image-editor')}>
+            <ImageCanvasControls initLabels={labels} />
+            <div className={cx('canvas-column')}>
+                <div className={cx('output-container')}>
+                    <Deferred>
+                        <ImageCanvasOutputClient 
+                            assetId={assetId} 
+                            timestamp={timestamp}
+                            dgid={dgid}
+                            imageSrc={`/api/image?${querystring}`}
+                        />
+                    </Deferred>
+                </div>
+            </div>
+        </div>
+      </CanvasProvider>
+    );
+};
+
+export default ExpandedCanvasClientSide;

--- a/frontend/app/cells/image/ImageCanvas/ImageCanvasCell.js
+++ b/frontend/app/cells/image/ImageCanvas/ImageCanvasCell.js
@@ -9,59 +9,15 @@ import Deferred from "../../../DeferredComponent";
 import CanvasProvider from "../../../contexts/CanvasContext";
 import fetchAssetMetadata from '../../../../lib/fetchAssetMetadata';
 import fetchAsset from '../../../../lib/fetchAsset';
+import ExpandedCanvasClientSide from "./ExpandedCanvasClientSide";
 
 const cx = classNames.bind(styles);
 
-const ImageCanvasCellStandAlone = async ({dgid, timestamp, assetId}) => {
-    const query = {
-        dgid,
-        timestamp,
-        assetId,
-    };
-    const metadata = await fetchAssetMetadata(query);
-
-    const getLabels = (metadata) => {
-        const labels = new Set();
-        if (typeof(metadata.annotations) !== 'undefined') {
-            for (const annotation of metadata.annotations) {
-                for (const data of annotation.data) {
-		    if (data.label)
-			labels.add(data.label);
-		    if (data.labels) {
-			for (const label of data.labels) {
-			    labels.add(label);
-			}
-		    }
-                }
-            }
-        }
-        return Array.from(labels);
-    };
-
-    const labels = getLabels(metadata);
-
-    const imageStore = {};
-    imageStore[assetId] = {
-        fetchedMeta: false
-    };
-
-    return (
-      <CanvasProvider value={{ images: imageStore, metadata, isGroup: false }}>
-        <div className={cx('image-editor')}>
-            <ImageCanvasControls initLabels={labels} />
-            <div className={cx('canvas-column')}>
-                <ImageCanvasOutput dgid={dgid} timestamp={timestamp} assetId={assetId} />
-            </div>
-        </div>
-      </CanvasProvider>
-    );
-};
 
 const ImageCanvasCell = async ({ assets, query }) => {
     const { dgid, timestamp } = query;
 
     const isGroup = typeof(query.groupBy) !== 'undefined';
-
     return (
         <Suspense fallback={<>Loading</>}>
             <div className={cx('image-editor')}>
@@ -74,14 +30,14 @@ const ImageCanvasCell = async ({ assets, query }) => {
                             } >
 
                                 <Suspense fallback={<>Loading</>}>
-                                    <ImageCanvasCellStandAlone dgid={dgid} timestamp={timestamp} assetId={id} />
+                                    <ExpandedCanvasClientSide dgid={dgid} timestamp={timestamp} assetId={id} /> 
                                 </Suspense>
 
                             </DialogueModal>
                         </Deferred>
                     ) ) : (
                       <Deferred>
-                          <ImageCanvasOutput dgid={dgid} timestamp={timestamp} assetId={assets[0]} />
+                          <ImageCanvasOutput dgid={dgid} timestamp={timestamp} assetId={assets?.[0]} />
                       </Deferred>
                     )}
                 </div>

--- a/frontend/lib/fetchAssetMetadata.js
+++ b/frontend/lib/fetchAssetMetadata.js
@@ -5,24 +5,16 @@ import config from '../config';
 import fetchData from './fetchData';
 import fetchIt from './fetchIt';
 
-const fetchAssetMetadata = async ({ assetId, dgid, timestamp }) => {
+const fetchAssetMetadata = async ({ assetId, dgid, timestamp, ssr=true}) => {
     const query = {
         assetId,
         dgid,
         timestamp,
     };
-    const data = await fetchIt({url: `${config.apiUrl}asset-metadata`, query});
-    /*
-    const data = await fetchData({
-        url: `${config.apiUrl}asset-metadata`,
-        query: {
-            assetId,
-            dgid,
-        },
-        method: 'POST',
-        returnType: 'json',
-    });
-    */
+    const data = ssr ?
+         await fetchIt({url: `${config.apiUrl}asset-metadata`, query}) :
+         await fetch(`${config.apiUrl}asset-metadata?assetId=${assetId}&dgid=${dgid}&timestamp=${timestamp}`)
+
     return data;
 };
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,7 +2,7 @@
   "name": "kangas-render-engine",
   "bin": "server.js",
   "scripts": {
-    "dev": "PORT=4000 NODE_ENV=development KANGAS_HOST=localhost KANGAS_BACKEND_PORT=4001 npx next dev",
+    "dev": "PORT=4000 NODE_ENV=development KANGAS_BACKEND_HOST=192.168.1.156 KANGAS_BACKEND_PORT=4001 KANGAS_FRONTEND_HOST=localhost KANGAS_FRONTEND_PORT=4000 KANGAS_FRONTEND_PROTOCOL=http KANGAS_BACKEND_PROTOCOL=http npx next dev",
     "buildPlain": "npx next build",
     "build": "npx next build; mv ./.next/static ./.next/standalone/.next; cp -r ./public ./.next/standalone/",
     "startPlain": "npx next start",


### PR DESCRIPTION
Defers the metadata fetching for single image modals until they are loaded into view