### PR TITLE
Add annotations to thumbnails

### DIFF
--- a/backend/kangas/datatypes/colormaps.py
+++ b/backend/kangas/datatypes/colormaps.py
@@ -1,0 +1,493 @@
+# -*- coding: utf-8 -*-
+######################################################
+#     _____                  _____      _     _      #
+#    (____ \       _        |  ___)    (_)   | |     #
+#     _   \ \ ____| |_  ____| | ___ ___ _  _ | |     #
+#    | |  | )/ _  |  _)/ _  | |(_  / __) |/ || |     #
+#    | |__/ ( ( | | | ( ( | | |__| | | | ( (_| |     #
+#    |_____/ \_||_|___)\_||_|_____/|_| |_|\____|     #
+#                                                    #
+#    Copyright (c) 2022 Kangas Development Team      #
+#    All rights reserved                             #
+######################################################
+
+
+def lerp(v0, v1, t):
+    #  linear interpolation
+    return v0 * (1 - t) + v1 * t
+
+
+color_scale = {
+    "jet": [
+        {"index": 0, "rgb": [0, 0, 131]},
+        {"index": 0.125, "rgb": [0, 60, 170]},
+        {"index": 0.375, "rgb": [5, 255, 255]},
+        {"index": 0.625, "rgb": [255, 255, 0]},
+        {"index": 0.875, "rgb": [250, 0, 0]},
+        {"index": 1, "rgb": [128, 0, 0]},
+    ],
+    "hsv": [
+        {"index": 0, "rgb": [255, 0, 0]},
+        {"index": 0.169, "rgb": [253, 255, 2]},
+        {"index": 0.173, "rgb": [247, 255, 2]},
+        {"index": 0.337, "rgb": [0, 252, 4]},
+        {"index": 0.341, "rgb": [0, 252, 10]},
+        {"index": 0.506, "rgb": [1, 249, 255]},
+        {"index": 0.671, "rgb": [2, 0, 253]},
+        {"index": 0.675, "rgb": [8, 0, 253]},
+        {"index": 0.839, "rgb": [255, 0, 251]},
+        {"index": 0.843, "rgb": [255, 0, 245]},
+        {"index": 1, "rgb": [255, 0, 6]},
+    ],
+    "hot": [
+        {"index": 0, "rgb": [0, 0, 0]},
+        {"index": 0.3, "rgb": [230, 0, 0]},
+        {"index": 0.6, "rgb": [255, 210, 0]},
+        {"index": 1, "rgb": [255, 255, 255]},
+    ],
+    "spring": [{"index": 0, "rgb": [255, 0, 255]}, {"index": 1, "rgb": [255, 255, 0]}],
+    "summer": [
+        {"index": 0, "rgb": [0, 128, 102]},
+        {"index": 1, "rgb": [255, 255, 102]},
+    ],
+    "autumn": [{"index": 0, "rgb": [255, 0, 0]}, {"index": 1, "rgb": [255, 255, 0]}],
+    "winter": [{"index": 0, "rgb": [0, 0, 255]}, {"index": 1, "rgb": [0, 255, 128]}],
+    "bone": [
+        {"index": 0, "rgb": [0, 0, 0]},
+        {"index": 0.376, "rgb": [84, 84, 116]},
+        {"index": 0.753, "rgb": [169, 200, 200]},
+        {"index": 1, "rgb": [255, 255, 255]},
+    ],
+    "copper": [
+        {"index": 0, "rgb": [0, 0, 0]},
+        {"index": 0.804, "rgb": [255, 160, 102]},
+        {"index": 1, "rgb": [255, 199, 127]},
+    ],
+    "greys": [{"index": 0, "rgb": [0, 0, 0]}, {"index": 1, "rgb": [255, 255, 255]}],
+    "yignbu": [
+        {"index": 0, "rgb": [8, 29, 88]},
+        {"index": 0.125, "rgb": [37, 52, 148]},
+        {"index": 0.25, "rgb": [34, 94, 168]},
+        {"index": 0.375, "rgb": [29, 145, 192]},
+        {"index": 0.5, "rgb": [65, 182, 196]},
+        {"index": 0.625, "rgb": [127, 205, 187]},
+        {"index": 0.75, "rgb": [199, 233, 180]},
+        {"index": 0.875, "rgb": [237, 248, 217]},
+        {"index": 1, "rgb": [255, 255, 217]},
+    ],
+    "greens": [
+        {"index": 0, "rgb": [0, 68, 27]},
+        {"index": 0.125, "rgb": [0, 109, 44]},
+        {"index": 0.25, "rgb": [35, 139, 69]},
+        {"index": 0.375, "rgb": [65, 171, 93]},
+        {"index": 0.5, "rgb": [116, 196, 118]},
+        {"index": 0.625, "rgb": [161, 217, 155]},
+        {"index": 0.75, "rgb": [199, 233, 192]},
+        {"index": 0.875, "rgb": [229, 245, 224]},
+        {"index": 1, "rgb": [247, 252, 245]},
+    ],
+    "yiorrd": [
+        {"index": 0, "rgb": [128, 0, 38]},
+        {"index": 0.125, "rgb": [189, 0, 38]},
+        {"index": 0.25, "rgb": [227, 26, 28]},
+        {"index": 0.375, "rgb": [252, 78, 42]},
+        {"index": 0.5, "rgb": [253, 141, 60]},
+        {"index": 0.625, "rgb": [254, 178, 76]},
+        {"index": 0.75, "rgb": [254, 217, 118]},
+        {"index": 0.875, "rgb": [255, 237, 160]},
+        {"index": 1, "rgb": [255, 255, 204]},
+    ],
+    "bluered": [{"index": 0, "rgb": [0, 0, 255]}, {"index": 1, "rgb": [255, 0, 0]}],
+    "rdbu": [
+        {"index": 0, "rgb": [5, 10, 172]},
+        {"index": 0.35, "rgb": [106, 137, 247]},
+        {"index": 0.5, "rgb": [190, 190, 190]},
+        {"index": 0.6, "rgb": [220, 170, 132]},
+        {"index": 0.7, "rgb": [230, 145, 90]},
+        {"index": 1, "rgb": [178, 10, 28]},
+    ],
+    "picnic": [
+        {"index": 0, "rgb": [0, 0, 255]},
+        {"index": 0.1, "rgb": [51, 153, 255]},
+        {"index": 0.2, "rgb": [102, 204, 255]},
+        {"index": 0.3, "rgb": [153, 204, 255]},
+        {"index": 0.4, "rgb": [204, 204, 255]},
+        {"index": 0.5, "rgb": [255, 255, 255]},
+        {"index": 0.6, "rgb": [255, 204, 255]},
+        {"index": 0.7, "rgb": [255, 153, 255]},
+        {"index": 0.8, "rgb": [255, 102, 204]},
+        {"index": 0.9, "rgb": [255, 102, 102]},
+        {"index": 1, "rgb": [255, 0, 0]},
+    ],
+    "rainbow": [
+        {"index": 0, "rgb": [150, 0, 90]},
+        {"index": 0.125, "rgb": [0, 0, 200]},
+        {"index": 0.25, "rgb": [0, 25, 255]},
+        {"index": 0.375, "rgb": [0, 152, 255]},
+        {"index": 0.5, "rgb": [44, 255, 150]},
+        {"index": 0.625, "rgb": [151, 255, 0]},
+        {"index": 0.75, "rgb": [255, 234, 0]},
+        {"index": 0.875, "rgb": [255, 111, 0]},
+        {"index": 1, "rgb": [255, 0, 0]},
+    ],
+    "portland": [
+        {"index": 0, "rgb": [12, 51, 131]},
+        {"index": 0.25, "rgb": [10, 136, 186]},
+        {"index": 0.5, "rgb": [242, 211, 56]},
+        {"index": 0.75, "rgb": [242, 143, 56]},
+        {"index": 1, "rgb": [217, 30, 30]},
+    ],
+    "blackbody": [
+        {"index": 0, "rgb": [0, 0, 0]},
+        {"index": 0.2, "rgb": [230, 0, 0]},
+        {"index": 0.4, "rgb": [230, 210, 0]},
+        {"index": 0.7, "rgb": [255, 255, 255]},
+        {"index": 1, "rgb": [160, 200, 255]},
+    ],
+    "earth": [
+        {"index": 0, "rgb": [0, 0, 130]},
+        {"index": 0.1, "rgb": [0, 180, 180]},
+        {"index": 0.2, "rgb": [40, 210, 40]},
+        {"index": 0.4, "rgb": [230, 230, 50]},
+        {"index": 0.6, "rgb": [120, 70, 20]},
+        {"index": 1, "rgb": [255, 255, 255]},
+    ],
+    "electric": [
+        {"index": 0, "rgb": [0, 0, 0]},
+        {"index": 0.15, "rgb": [30, 0, 100]},
+        {"index": 0.4, "rgb": [120, 0, 100]},
+        {"index": 0.6, "rgb": [160, 90, 0]},
+        {"index": 0.8, "rgb": [230, 200, 0]},
+        {"index": 1, "rgb": [255, 250, 220]},
+    ],
+    "alpha": [
+        {"index": 0, "rgb": [255, 255, 255, 0]},
+        {"index": 1, "rgb": [255, 255, 255, 1]},
+    ],
+    "viridis": [
+        {"index": 0, "rgb": [68, 1, 84]},
+        {"index": 0.13, "rgb": [71, 44, 122]},
+        {"index": 0.25, "rgb": [59, 81, 139]},
+        {"index": 0.38, "rgb": [44, 113, 142]},
+        {"index": 0.5, "rgb": [33, 144, 141]},
+        {"index": 0.63, "rgb": [39, 173, 129]},
+        {"index": 0.75, "rgb": [92, 200, 99]},
+        {"index": 0.88, "rgb": [170, 220, 50]},
+        {"index": 1, "rgb": [253, 231, 37]},
+    ],
+    "inferno": [
+        {"index": 0, "rgb": [0, 0, 4]},
+        {"index": 0.13, "rgb": [31, 12, 72]},
+        {"index": 0.25, "rgb": [85, 15, 109]},
+        {"index": 0.38, "rgb": [136, 34, 106]},
+        {"index": 0.5, "rgb": [186, 54, 85]},
+        {"index": 0.63, "rgb": [227, 89, 51]},
+        {"index": 0.75, "rgb": [249, 140, 10]},
+        {"index": 0.88, "rgb": [249, 201, 50]},
+        {"index": 1, "rgb": [252, 255, 164]},
+    ],
+    "magma": [
+        {"index": 0, "rgb": [0, 0, 4]},
+        {"index": 0.13, "rgb": [28, 16, 68]},
+        {"index": 0.25, "rgb": [79, 18, 123]},
+        {"index": 0.38, "rgb": [129, 37, 129]},
+        {"index": 0.5, "rgb": [181, 54, 122]},
+        {"index": 0.63, "rgb": [229, 80, 100]},
+        {"index": 0.75, "rgb": [251, 135, 97]},
+        {"index": 0.88, "rgb": [254, 194, 135]},
+        {"index": 1, "rgb": [252, 253, 191]},
+    ],
+    "plasma": [
+        {"index": 0, "rgb": [13, 8, 135]},
+        {"index": 0.13, "rgb": [75, 3, 161]},
+        {"index": 0.25, "rgb": [125, 3, 168]},
+        {"index": 0.38, "rgb": [168, 34, 150]},
+        {"index": 0.5, "rgb": [203, 70, 121]},
+        {"index": 0.63, "rgb": [229, 107, 93]},
+        {"index": 0.75, "rgb": [248, 148, 65]},
+        {"index": 0.88, "rgb": [253, 195, 40]},
+        {"index": 1, "rgb": [240, 249, 33]},
+    ],
+    "warm": [
+        {"index": 0, "rgb": [125, 0, 179]},
+        {"index": 0.13, "rgb": [172, 0, 187]},
+        {"index": 0.25, "rgb": [219, 0, 170]},
+        {"index": 0.38, "rgb": [255, 0, 130]},
+        {"index": 0.5, "rgb": [255, 63, 74]},
+        {"index": 0.63, "rgb": [255, 123, 0]},
+        {"index": 0.75, "rgb": [234, 176, 0]},
+        {"index": 0.88, "rgb": [190, 228, 0]},
+        {"index": 1, "rgb": [147, 255, 0]},
+    ],
+    "cool": [
+        {"index": 0, "rgb": [125, 0, 179]},
+        {"index": 0.13, "rgb": [116, 0, 218]},
+        {"index": 0.25, "rgb": [98, 74, 237]},
+        {"index": 0.38, "rgb": [68, 146, 231]},
+        {"index": 0.5, "rgb": [0, 204, 197]},
+        {"index": 0.63, "rgb": [0, 247, 146]},
+        {"index": 0.75, "rgb": [0, 255, 88]},
+        {"index": 0.88, "rgb": [40, 255, 8]},
+        {"index": 1, "rgb": [147, 255, 0]},
+    ],
+    "rainbow-soft": [
+        {"index": 0, "rgb": [125, 0, 179]},
+        {"index": 0.1, "rgb": [199, 0, 180]},
+        {"index": 0.2, "rgb": [255, 0, 121]},
+        {"index": 0.3, "rgb": [255, 108, 0]},
+        {"index": 0.4, "rgb": [222, 194, 0]},
+        {"index": 0.5, "rgb": [150, 255, 0]},
+        {"index": 0.6, "rgb": [0, 255, 55]},
+        {"index": 0.7, "rgb": [0, 246, 150]},
+        {"index": 0.8, "rgb": [50, 167, 222]},
+        {"index": 0.9, "rgb": [103, 51, 235]},
+        {"index": 1, "rgb": [124, 0, 186]},
+    ],
+    "bathymetry": [
+        {"index": 0, "rgb": [40, 26, 44]},
+        {"index": 0.13, "rgb": [59, 49, 90]},
+        {"index": 0.25, "rgb": [64, 76, 139]},
+        {"index": 0.38, "rgb": [63, 110, 151]},
+        {"index": 0.5, "rgb": [72, 142, 158]},
+        {"index": 0.63, "rgb": [85, 174, 163]},
+        {"index": 0.75, "rgb": [120, 206, 163]},
+        {"index": 0.88, "rgb": [187, 230, 172]},
+        {"index": 1, "rgb": [253, 254, 204]},
+    ],
+    "cdom": [
+        {"index": 0, "rgb": [47, 15, 62]},
+        {"index": 0.13, "rgb": [87, 23, 86]},
+        {"index": 0.25, "rgb": [130, 28, 99]},
+        {"index": 0.38, "rgb": [171, 41, 96]},
+        {"index": 0.5, "rgb": [206, 67, 86]},
+        {"index": 0.63, "rgb": [230, 106, 84]},
+        {"index": 0.75, "rgb": [242, 149, 103]},
+        {"index": 0.88, "rgb": [249, 193, 135]},
+        {"index": 1, "rgb": [254, 237, 176]},
+    ],
+    "chlorophyll": [
+        {"index": 0, "rgb": [18, 36, 20]},
+        {"index": 0.13, "rgb": [25, 63, 41]},
+        {"index": 0.25, "rgb": [24, 91, 59]},
+        {"index": 0.38, "rgb": [13, 119, 72]},
+        {"index": 0.5, "rgb": [18, 148, 80]},
+        {"index": 0.63, "rgb": [80, 173, 89]},
+        {"index": 0.75, "rgb": [132, 196, 122]},
+        {"index": 0.88, "rgb": [175, 221, 162]},
+        {"index": 1, "rgb": [215, 249, 208]},
+    ],
+    "density": [
+        {"index": 0, "rgb": [54, 14, 36]},
+        {"index": 0.13, "rgb": [89, 23, 80]},
+        {"index": 0.25, "rgb": [110, 45, 132]},
+        {"index": 0.38, "rgb": [120, 77, 178]},
+        {"index": 0.5, "rgb": [120, 113, 213]},
+        {"index": 0.63, "rgb": [115, 151, 228]},
+        {"index": 0.75, "rgb": [134, 185, 227]},
+        {"index": 0.88, "rgb": [177, 214, 227]},
+        {"index": 1, "rgb": [230, 241, 241]},
+    ],
+    "freesurface-blue": [
+        {"index": 0, "rgb": [30, 4, 110]},
+        {"index": 0.13, "rgb": [47, 14, 176]},
+        {"index": 0.25, "rgb": [41, 45, 236]},
+        {"index": 0.38, "rgb": [25, 99, 212]},
+        {"index": 0.5, "rgb": [68, 131, 200]},
+        {"index": 0.63, "rgb": [114, 156, 197]},
+        {"index": 0.75, "rgb": [157, 181, 203]},
+        {"index": 0.88, "rgb": [200, 208, 216]},
+        {"index": 1, "rgb": [241, 237, 236]},
+    ],
+    "freesurface-red": [
+        {"index": 0, "rgb": [60, 9, 18]},
+        {"index": 0.13, "rgb": [100, 17, 27]},
+        {"index": 0.25, "rgb": [142, 20, 29]},
+        {"index": 0.38, "rgb": [177, 43, 27]},
+        {"index": 0.5, "rgb": [192, 87, 63]},
+        {"index": 0.63, "rgb": [205, 125, 105]},
+        {"index": 0.75, "rgb": [216, 162, 148]},
+        {"index": 0.88, "rgb": [227, 199, 193]},
+        {"index": 1, "rgb": [241, 237, 236]},
+    ],
+    "oxygen": [
+        {"index": 0, "rgb": [64, 5, 5]},
+        {"index": 0.13, "rgb": [106, 6, 15]},
+        {"index": 0.25, "rgb": [144, 26, 7]},
+        {"index": 0.38, "rgb": [168, 64, 3]},
+        {"index": 0.5, "rgb": [188, 100, 4]},
+        {"index": 0.63, "rgb": [206, 136, 11]},
+        {"index": 0.75, "rgb": [220, 174, 25]},
+        {"index": 0.88, "rgb": [231, 215, 44]},
+        {"index": 1, "rgb": [248, 254, 105]},
+    ],
+    "par": [
+        {"index": 0, "rgb": [51, 20, 24]},
+        {"index": 0.13, "rgb": [90, 32, 35]},
+        {"index": 0.25, "rgb": [129, 44, 34]},
+        {"index": 0.38, "rgb": [159, 68, 25]},
+        {"index": 0.5, "rgb": [182, 99, 19]},
+        {"index": 0.63, "rgb": [199, 134, 22]},
+        {"index": 0.75, "rgb": [212, 171, 35]},
+        {"index": 0.88, "rgb": [221, 210, 54]},
+        {"index": 1, "rgb": [225, 253, 75]},
+    ],
+    "phase": [
+        {"index": 0, "rgb": [145, 105, 18]},
+        {"index": 0.13, "rgb": [184, 71, 38]},
+        {"index": 0.25, "rgb": [186, 58, 115]},
+        {"index": 0.38, "rgb": [160, 71, 185]},
+        {"index": 0.5, "rgb": [110, 97, 218]},
+        {"index": 0.63, "rgb": [50, 123, 164]},
+        {"index": 0.75, "rgb": [31, 131, 110]},
+        {"index": 0.88, "rgb": [77, 129, 34]},
+        {"index": 1, "rgb": [145, 105, 18]},
+    ],
+    "salinity": [
+        {"index": 0, "rgb": [42, 24, 108]},
+        {"index": 0.13, "rgb": [33, 50, 162]},
+        {"index": 0.25, "rgb": [15, 90, 145]},
+        {"index": 0.38, "rgb": [40, 118, 137]},
+        {"index": 0.5, "rgb": [59, 146, 135]},
+        {"index": 0.63, "rgb": [79, 175, 126]},
+        {"index": 0.75, "rgb": [120, 203, 104]},
+        {"index": 0.88, "rgb": [193, 221, 100]},
+        {"index": 1, "rgb": [253, 239, 154]},
+    ],
+    "temperature": [
+        {"index": 0, "rgb": [4, 35, 51]},
+        {"index": 0.13, "rgb": [23, 51, 122]},
+        {"index": 0.25, "rgb": [85, 59, 157]},
+        {"index": 0.38, "rgb": [129, 79, 143]},
+        {"index": 0.5, "rgb": [175, 95, 130]},
+        {"index": 0.63, "rgb": [222, 112, 101]},
+        {"index": 0.75, "rgb": [249, 146, 66]},
+        {"index": 0.88, "rgb": [249, 196, 65]},
+        {"index": 1, "rgb": [232, 250, 91]},
+    ],
+    "turbidity": [
+        {"index": 0, "rgb": [34, 31, 27]},
+        {"index": 0.13, "rgb": [65, 50, 41]},
+        {"index": 0.25, "rgb": [98, 69, 52]},
+        {"index": 0.38, "rgb": [131, 89, 57]},
+        {"index": 0.5, "rgb": [161, 112, 59]},
+        {"index": 0.63, "rgb": [185, 140, 66]},
+        {"index": 0.75, "rgb": [202, 174, 88]},
+        {"index": 0.88, "rgb": [216, 209, 126]},
+        {"index": 1, "rgb": [233, 246, 171]},
+    ],
+    "velocity-blue": [
+        {"index": 0, "rgb": [17, 32, 64]},
+        {"index": 0.13, "rgb": [35, 52, 116]},
+        {"index": 0.25, "rgb": [29, 81, 156]},
+        {"index": 0.38, "rgb": [31, 113, 162]},
+        {"index": 0.5, "rgb": [50, 144, 169]},
+        {"index": 0.63, "rgb": [87, 173, 176]},
+        {"index": 0.75, "rgb": [149, 196, 189]},
+        {"index": 0.88, "rgb": [203, 221, 211]},
+        {"index": 1, "rgb": [254, 251, 230]},
+    ],
+    "velocity-green": [
+        {"index": 0, "rgb": [23, 35, 19]},
+        {"index": 0.13, "rgb": [24, 64, 38]},
+        {"index": 0.25, "rgb": [11, 95, 45]},
+        {"index": 0.38, "rgb": [39, 123, 35]},
+        {"index": 0.5, "rgb": [95, 146, 12]},
+        {"index": 0.63, "rgb": [152, 165, 18]},
+        {"index": 0.75, "rgb": [201, 186, 69]},
+        {"index": 0.88, "rgb": [233, 216, 137]},
+        {"index": 1, "rgb": [255, 253, 205]},
+    ],
+    "cubehelix": [
+        {"index": 0, "rgb": [0, 0, 0]},
+        {"index": 0.07, "rgb": [22, 5, 59]},
+        {"index": 0.13, "rgb": [60, 4, 105]},
+        {"index": 0.2, "rgb": [109, 1, 135]},
+        {"index": 0.27, "rgb": [161, 0, 147]},
+        {"index": 0.33, "rgb": [210, 2, 142]},
+        {"index": 0.4, "rgb": [251, 11, 123]},
+        {"index": 0.47, "rgb": [255, 29, 97]},
+        {"index": 0.53, "rgb": [255, 54, 69]},
+        {"index": 0.6, "rgb": [255, 85, 46]},
+        {"index": 0.67, "rgb": [255, 120, 34]},
+        {"index": 0.73, "rgb": [255, 157, 37]},
+        {"index": 0.8, "rgb": [241, 191, 57]},
+        {"index": 0.87, "rgb": [224, 220, 93]},
+        {"index": 0.93, "rgb": [218, 241, 142]},
+        {"index": 1, "rgb": [227, 253, 198]},
+    ],
+}
+
+
+def create_colormap(spec=None):
+    if spec is None:
+        spec = {}
+
+    alpha = [1, 1]
+    nshades = (72 if "nshades" not in spec else spec["nshades"]) - 1
+    format = "rgb" if "format" not in spec else spec["format"]
+
+    colormap = (spec["colormap"] if "colormap" in spec else "jet").lower()
+
+    if colormap not in color_scale:
+        raise Exception(colormap + " not a supported colorscale")
+
+    cmap = color_scale[colormap]
+
+    # map index points from 0..1 to 0..n-1
+    indicies = [round(d["index"] * nshades) for d in cmap]
+
+    # Add alpha channel to the map
+    alpha[0] = min(max(alpha[0], 0), 1)
+    alpha[1] = min(max(alpha[1], 0), 1)
+
+    def get_steps(d):
+        index = d["index"]
+        rgba = d["rgb"]
+
+        # if user supplies their own map use it
+        if len(rgba) == 4 and rgba[3] >= 0 and rgba[3] <= 1:
+            return rgba
+
+        if len(rgba) == 3:
+            rgba += [alpha[0] + (alpha[1] - alpha[0]) * index]
+        else:
+            rgba[3] = alpha[0] + (alpha[1] - alpha[0]) * index
+        return rgba
+
+    steps = [get_steps(d) for d in cmap]
+
+    # map increasing linear values between indicies to
+    # linear steps in colorvalues
+    colors = []
+    for i in range(len(indicies) - 1):
+        nsteps = indicies[i + 1] - indicies[i]
+        fromrgba = steps[i]
+        torgba = steps[i + 1]
+
+        for j in range(nsteps):
+            amt = j / nsteps
+            colors.append(
+                [
+                    round(lerp(fromrgba[0], torgba[0], amt)),
+                    round(lerp(fromrgba[1], torgba[1], amt)),
+                    round(lerp(fromrgba[2], torgba[2], amt)),
+                    lerp(fromrgba[3], torgba[3], amt),
+                ]
+            )
+
+    # add 1 step as last value
+    colors.append(cmap[len(cmap) - 1]["rgb"])
+
+    if format == "hex":
+        return list(map(rgb2hex, colors))
+    elif format == "rgb":
+        return [color[:3] for color in colors]
+    else:
+        raise Exception(
+            "unknown colormap format %r: should be 'hex', or 'rgb'" % format
+        )
+
+
+def rgb2hex(rgb):
+    hex = "#" + ("".join(["{:02x}".format(v) for v in rgb[:3]]))
+    return hex

--- a/backend/kangas/datatypes/utils.py
+++ b/backend/kangas/datatypes/utils.py
@@ -598,8 +598,6 @@ def draw_annotations_on_image(image, metadata):
                         mask["height"] / image.size[1]
                     )  # don't assume it keeps aspect ratio
                     if mask["type"] == "segmentation":
-                        # FIXME: some colors are wrong; why?
-                        # class_id -> label
                         palette = {
                             int(index): get_rgb_from_hex(
                                 get_color(make_tag(annotation_layer["name"], label))

--- a/backend/kangas/datatypes/utils.py
+++ b/backend/kangas/datatypes/utils.py
@@ -526,7 +526,7 @@ def get_color(text):
     if text.lower() in ["0", "false", "f", "no"]:
         return "#cf0057"  # red from palette
     hash = functools.reduce(
-        lambda acc, c: (ord(c) + ((acc << 5) - acc)) & 0xFFFFFFFF, text, 0
+        lambda acc, c: ((ord(c) + ((acc << 5) - acc)) & 0x7FFFFFFF), text, 0
     )
     return get_unique_color(abs(hash))
 

--- a/backend/kangas/datatypes/utils.py
+++ b/backend/kangas/datatypes/utils.py
@@ -574,7 +574,7 @@ def draw_annotations_on_image(image, metadata):
 
     from .colormaps import create_colormap
 
-    canvas = ImageDraw.Draw(image)
+    canvas = None
     pixels = None
     metadata = json.loads(metadata)
     if "annotations" in metadata:
@@ -650,6 +650,8 @@ def draw_annotations_on_image(image, metadata):
         for annotation_layer in metadata["annotations"]:
             for annotation in annotation_layer["data"]:
                 if "boxes" in annotation and annotation["boxes"]:
+                    if canvas is None:
+                        canvas = ImageDraw.Draw(image)
                     color = get_color(annotation["label"])
                     for box in annotation["boxes"]:
                         x, y, w, h = box
@@ -661,12 +663,16 @@ def draw_annotations_on_image(image, metadata):
                             outline=color,
                         )
                 if "points" in annotation and annotation["points"]:
+                    if canvas is None:
+                        canvas = ImageDraw.Draw(image)
                     color = get_color(annotation["label"])
                     for region in annotation["points"]:
                         canvas.polygon([value * scale for value in region], fill=color)
                 if "markers" in annotation and annotation["markers"]:
-                    pass
+                    pass  # too small to see
                 if "lines" in annotation and annotation["lines"]:
+                    if canvas is None:
+                        canvas = ImageDraw.Draw(image)
                     color = get_color(annotation["label"])
                     for line in annotation["lines"]:
                         x1, y1, x2, y2 = line

--- a/backend/kangas/datatypes/utils.py
+++ b/backend/kangas/datatypes/utils.py
@@ -525,7 +525,9 @@ def get_color(text):
         return "#12a592"  # green from palette
     if text.lower() in ["0", "false", "f", "no"]:
         return "#cf0057"  # red from palette
-    hash = functools.reduce(lambda acc, c: ord(c) + ((acc << 5) - acc), text, 0)
+    hash = functools.reduce(
+        lambda acc, c: (ord(c) + ((acc << 5) - acc)) & 0xFFFFFFFF, text, 0
+    )
     return get_unique_color(abs(hash))
 
 

--- a/frontend/lib/canvas.js
+++ b/frontend/lib/canvas.js
@@ -143,10 +143,12 @@ const makeSegmentationMaskImage = (mask, hiddenLabels, layerName, scores, score,
                     continue;
                 let pos = (y * mask.width + x) * 4;
 		const rgb = rgbMap[label];
-                buffer[pos  ] = rgb[0];
-                buffer[pos+1] = rgb[1];
-                buffer[pos+2] = rgb[2];
-                buffer[pos+3] = alpha;
+		if (rgb) {
+                    buffer[pos  ] = rgb[0];
+                    buffer[pos+1] = rgb[1];
+                    buffer[pos+2] = rgb[2];
+                    buffer[pos+3] = alpha;
+		}
             }
         }
     }
@@ -187,10 +189,12 @@ const makeMetricMaskImage = (mask, alpha) => {
             if (value > 0) {
                 // Show metric with some transparency
                 const rgba = colorMap[value]
-                buffer[pos  ] = rgba[0];
-                buffer[pos+1] = rgba[1];
-                buffer[pos+2] = rgba[2];
-                buffer[pos+3] = 200; // FIXME: get alpha from a control
+		if (rgba) {
+                    buffer[pos  ] = rgba[0];
+                    buffer[pos+1] = rgba[1];
+                    buffer[pos+2] = rgba[2];
+                    buffer[pos+3] = 200; // FIXME: get alpha from a control
+		}
             } else {
                 // transparent
                 buffer[pos  ] = 0;

--- a/frontend/lib/generateChartColor.js
+++ b/frontend/lib/generateChartColor.js
@@ -74,7 +74,7 @@ export const getColor = (text = '0') => {
     if (['0', 'false', 'f', 'no'].includes(text.toLowerCase()))
         return '#cf0057'; // red from palette
     const hash = [...text].reduce((acc, char) => {
-        return (char.charCodeAt(0) + (shift(acc, 5) - acc)) & 0xFFFFFFFF;
+        return (char.charCodeAt(0) + (shift(acc, 5) - acc)) & 0x7FFFFFFF;
     }, 0);
     return getUniqueColor(Math.abs(hash));
 };

--- a/frontend/lib/generateChartColor.js
+++ b/frontend/lib/generateChartColor.js
@@ -60,6 +60,10 @@ const getUniqueColor = (hash) => {
     return colors[hash % colors.length];
 };
 
+function shift(number, shift) {
+    return number * Math.pow(2, shift);
+}
+
 export const getColor = (text = '0') => {
     if (!text)
 	return '#000000'; // black, error
@@ -70,7 +74,7 @@ export const getColor = (text = '0') => {
     if (['0', 'false', 'f', 'no'].includes(text.toLowerCase()))
         return '#cf0057'; // red from palette
     const hash = [...text].reduce((acc, char) => {
-        return char.charCodeAt(0) + ((acc << 5) - acc);
+        return char.charCodeAt(0) + (shift(acc, 5) - acc);
     }, 0);
     return getUniqueColor(Math.abs(hash));
 };

--- a/frontend/lib/generateChartColor.js
+++ b/frontend/lib/generateChartColor.js
@@ -74,7 +74,7 @@ export const getColor = (text = '0') => {
     if (['0', 'false', 'f', 'no'].includes(text.toLowerCase()))
         return '#cf0057'; // red from palette
     const hash = [...text].reduce((acc, char) => {
-        return char.charCodeAt(0) + (shift(acc, 5) - acc);
+        return (char.charCodeAt(0) + (shift(acc, 5) - acc)) & 0xFFFFFFFF;
     }, 0);
     return getUniqueColor(Math.abs(hash));
 };


### PR DESCRIPTION
Annotations are too useful, and so we want to see/use them as much as possible, if they can be drawn quickly. 

This PR adds the quick-drawing annotations to thumbnails: lines, regions, segmentation masks, metric masks, and bounding boxes. 

One consequence of this PR: I had to change the color mapping from text to colors slightly in order to replicate it in Python. The Javascript version relied on some esoteric aspects of Javascript (32-bit shifts, 64-bit max, etc).

After:

![Screenshot from 2023-03-27 16-30-39](https://user-images.githubusercontent.com/168568/228090060-c02b3b64-6b07-47a7-95c8-a07f877060fc.png)

![Screenshot from 2023-03-27 16-30-17](https://user-images.githubusercontent.com/168568/228090062-714c0f7c-d761-461f-9a28-b64147f0db6b.png)

![Screenshot from 2023-03-28 11-22-08](https://user-images.githubusercontent.com/168568/228332061-9337ade2-5ba4-41f6-b733-90d18a7408bd.png)

![Screenshot from 2023-03-28 11-21-24](https://user-images.githubusercontent.com/168568/228332064-be6fbfcc-fa81-4e8d-b9e5-7137e79e67f1.png)

