### PR TITLE
Get scatter color from trace; don't use /api/charts for large scatter plots

### DIFF
--- a/backend/kangas/server/queries.py
+++ b/backend/kangas/server/queries.py
@@ -2178,10 +2178,9 @@ def select_pca_data(dgid, asset_id, column_name, column_value, group_by, where_e
                     {
                         "x": xs,
                         "y": ys,
-                        "color": colors,
                         "type": "scatter",
                         "mode": "markers",
-                        "marker": {"size": 3, "color": color},
+                        "marker": {"size": 3, "color": colors},
                     }
                 )
 
@@ -2475,7 +2474,7 @@ def generate_chart_image(chart_type, data, width, height):
             span_y = max_y - min_y
 
             radius = trace["marker"]["size"] / 2
-            default_color = trace["marker"]["color"]
+            colors = trace["marker"]["color"]
             margin = 5
 
             total_width = width - margin * 2
@@ -2491,10 +2490,10 @@ def generate_chart_image(chart_type, data, width, height):
             )
 
             for count, [x, y] in enumerate(zip(trace["x"], trace["y"])):
-                if "color" in trace and trace["color"] and trace["color"][count]:
-                    color = trace["color"][count]
+                if isinstance(colors, list):
+                    color = colors[count]
                 else:
-                    color = default_color
+                    color = colors
                 drawing.ellipse(
                     [
                         margin + (total_width * (x - min_x) / span_x) - radius,

--- a/frontend/app/cells/charts/histogram/Histogram.js
+++ b/frontend/app/cells/charts/histogram/Histogram.js
@@ -1,15 +1,10 @@
 import fetchHistogram from "../../../../lib/fetchHistogram"
 import HistogramClient from "./HistogramClient";
-import classNames from 'classnames/bind';
-import styles from '../Charts.module.scss'
-
-const cx = classNames.bind(styles);
 
 const Histogram = async ({ value, expanded, ssr }) => {
     const ssrData = ssr ? await fetchHistogram(value, ssr) : false; 
     
     return <HistogramClient expanded={expanded} value={value} ssrData={ssrData} />;
-    
 }
 
 export default Histogram;

--- a/frontend/app/cells/embedding/EmbeddingCellClient.js
+++ b/frontend/app/cells/embedding/EmbeddingCellClient.js
@@ -88,34 +88,35 @@ const EmbeddingClient = ({ value, expanded, query, columnName, ssrData }) => {
     }, [columnName]);
 
 
+    const getQueryParams = (query, value, columnName) => {
+        if (!query?.groupBy) {
+            return {dgid: query?.dgid, timestamp: query?.timestamp, columnName, assetId: value?.assetId};
+        } else {
+            return {dgid: query?.dgid, timestamp: query?.timestamp, columnName, columnValue: value?.columnValue,
+                    groupBy: value?.groupBy, whereExpr: value?.whereExpr};
+        }
+    };
+
     useEffect(() => {
         if (!value || ssrData || !query) return;
 
-        if (!query?.groupBy) {
-            fetchEmbeddingsAsPCA({dgid: query?.dgid, timestamp: query?.timestamp, columnName, assetId: value?.assetId}).then(res => {
-                setResponse(res);
-            });
-        } else {
-            fetchEmbeddingsAsPCA({dgid: query?.dgid, timestamp: query?.timestamp, columnName, columnValue: value?.columnValue,
-                                  groupBy: value?.groupBy, whereExpr: value?.whereExpr}).then(res => {
-                                      setResponse(res);
-                                  });
-        }
+        const queryParams = getQueryParams(query, value, columnName);
+
+        fetchEmbeddingsAsPCA(queryParams).then(res => {
+            setResponse(res);
+        });
     }, [value, query, ssrData]);
 
 
     const queryString = useMemo(() => {
-        if (!data) return;
+        if (!query?.dgid) return;
 
         return new URLSearchParams(
             Object.fromEntries(
-                Object.entries({
-                    chartType: 'scatter',
-                    data: JSON.stringify(data)
-                }).filter(([k, v]) => typeof(v) !== 'undefined' && v !== null)
+                Object.entries({...getQueryParams(query, value, columnName), thumbnail: true}).filter(([k, v]) => typeof(v) !== 'undefined' && v !== null)
             )
         ).toString();
-    }, [data]);
+    }, [query, value, columnName]);
 
 
     if (!data || data?.error) {
@@ -124,9 +125,9 @@ const EmbeddingClient = ({ value, expanded, query, columnName, ssrData }) => {
 
     if (!expanded) {
         if (!query?.groupBy) {
-            return (<img src={`${config.rootPath}api/charts?${queryString}`} loading="lazy" className={cx(['chart-thumbnail', 'embedding'])} />);
+            return (<img src={`${config.rootPath}api/embeddings-as-pca?${queryString}`} loading="lazy" className={cx(['chart-thumbnail', 'embedding'])} />);
         } else {
-            return (<img src={`${config.rootPath}api/charts?${queryString}`} loading="lazy" className={cx(['chart-thumbnail', 'embedding-grouped'])} />);
+            return (<img src={`${config.rootPath}api/embeddings-as-pca?${queryString}`} loading="lazy" className={cx(['chart-thumbnail', 'embedding-grouped'])} />);
         }
     }
 

--- a/frontend/app/cells/embedding/EmbeddingCellClient.js
+++ b/frontend/app/cells/embedding/EmbeddingCellClient.js
@@ -88,24 +88,33 @@ const EmbeddingClient = ({ value, expanded, query, columnName, ssrData }) => {
     }, [columnName]);
 
 
-    const getQueryParams = (query, value, columnName) => {
+    const queryParams = useMemo(() => {
         if (!query?.groupBy) {
-            return {dgid: query?.dgid, timestamp: query?.timestamp, columnName, assetId: value?.assetId};
+            return {
+                dgid: query?.dgid,
+                timestamp: query?.timestamp,
+                columnName,
+                assetId: value?.assetId
+            };
         } else {
-            return {dgid: query?.dgid, timestamp: query?.timestamp, columnName, columnValue: value?.columnValue,
-                    groupBy: value?.groupBy, whereExpr: value?.whereExpr};
+            return {
+                dgid: query?.dgid, 
+                timestamp: query?.timestamp, 
+                columnName, 
+                columnValue: value?.columnValue,
+                groupBy: value?.groupBy, 
+                whereExpr: value?.whereExpr
+            };
         }
-    };
+    }, [query, value, columnName]);
 
     useEffect(() => {
-        if (!value || ssrData || !query) return;
-
-        const queryParams = getQueryParams(query, value, columnName);
+        if (ssrData || !queryParams) return;
 
         fetchEmbeddingsAsPCA(queryParams).then(res => {
             setResponse(res);
         });
-    }, [value, query, ssrData]);
+    }, [ssrData, queryParams]);
 
 
     const queryString = useMemo(() => {
@@ -113,10 +122,13 @@ const EmbeddingClient = ({ value, expanded, query, columnName, ssrData }) => {
 
         return new URLSearchParams(
             Object.fromEntries(
-                Object.entries({...getQueryParams(query, value, columnName), thumbnail: true}).filter(([k, v]) => typeof(v) !== 'undefined' && v !== null)
+                Object.entries({
+                    ...queryParams, 
+                    thumbnail: true
+                }).filter(([k, v]) => typeof(v) !== 'undefined' && v !== null)
             )
         ).toString();
-    }, [query, value, columnName]);
+    }, [queryParams]);
 
 
     if (!data || data?.error) {
@@ -125,9 +137,21 @@ const EmbeddingClient = ({ value, expanded, query, columnName, ssrData }) => {
 
     if (!expanded) {
         if (!query?.groupBy) {
-            return (<img src={`${config.rootPath}api/embeddings-as-pca?${queryString}`} loading="lazy" className={cx(['chart-thumbnail', 'embedding'])} />);
+            return (
+                <img 
+                    src={`${config.rootPath}api/embeddings-as-pca?${queryString}`} 
+                    loading="lazy"
+                    className={cx(['chart-thumbnail', 'embedding'])} 
+                />
+            );
         } else {
-            return (<img src={`${config.rootPath}api/embeddings-as-pca?${queryString}`} loading="lazy" className={cx(['chart-thumbnail', 'embedding-grouped'])} />);
+            return (
+                <img 
+                    src={`${config.rootPath}api/embeddings-as-pca?${queryString}`} 
+                    loading="lazy" 
+                    className={cx(['chart-thumbnail', 'embedding-grouped'])} 
+                />
+            );
         }
     }
 


### PR DESCRIPTION
Adds the color to the trace for scatter plots. But this makes 33% larger URLs for the thumbnail maker. So, had to create a way to make thumbnails directly.
