### PR TITLE
Rename Vector asset to Tensor

### DIFF
--- a/backend/kangas/__init__.py
+++ b/backend/kangas/__init__.py
@@ -22,8 +22,8 @@ from .datatypes import (  # noqa
     DataGrid,
     Embedding,
     Image,
+    Tensor,
     Text,
-    Vector,
     Video,
 )
 from .integrations import export_to_comet, import_from_comet  # noqa

--- a/backend/kangas/datatypes/__init__.py
+++ b/backend/kangas/datatypes/__init__.py
@@ -18,8 +18,8 @@ from .datagrid import DataGrid  # noqa
 from .embedding import Embedding
 from .image import Image
 from .serialize import register_asset_type
+from .tensor import Tensor
 from .text import Text
-from .vector import Vector
 from .video import Video
 
 for name, cls, asset_type in [
@@ -30,6 +30,6 @@ for name, cls, asset_type in [
     ("TEXT-ASSET", Text, "text"),
     ("VIDEO-ASSET", Video, "video"),
     ("EMBEDDING-ASSET", Embedding, "embedding"),
-    ("VECTOR-ASSET", Vector, "vector"),
+    ("TENSOR-ASSET", Tensor, "tensor"),
 ]:
     register_asset_type(name, cls, asset_type)

--- a/backend/kangas/datatypes/embedding.py
+++ b/backend/kangas/datatypes/embedding.py
@@ -67,9 +67,10 @@ class Embedding(Asset):
         """
         super().__init__(source)
         if unserialize:
+            self._unserialize = unserialize
             return
         if self.source is not None:
-            # FIXME: this is for images, not others
+            # FIXME: this is for images, not others?
             self._log_metadata(
                 filename=self.source,
                 extension=get_file_extension(self.source),

--- a/backend/kangas/datatypes/image.py
+++ b/backend/kangas/datatypes/image.py
@@ -110,6 +110,7 @@ class Image(Asset):
             self._unserialize = unserialize
             return
         if self.source is not None:
+            # FIXME: this is for images, not others?
             filename = self.source
             self._log_metadata(
                 name=name,

--- a/backend/kangas/datatypes/tensor.py
+++ b/backend/kangas/datatypes/tensor.py
@@ -25,7 +25,7 @@ class Tensor(Asset):
 
     def __init__(
         self,
-        tensor,
+        tensor=None,
         metadata=None,
         unserialize=False,
     ):
@@ -48,6 +48,7 @@ class Tensor(Asset):
         """
         super().__init__()
         if unserialize:
+            self._unserialize = unserialize
             return
 
         self.asset_data = json.dumps(tensor)

--- a/backend/kangas/datatypes/tensor.py
+++ b/backend/kangas/datatypes/tensor.py
@@ -16,24 +16,24 @@ import json
 from .base import Asset
 
 
-class Vector(Asset):
+class Tensor(Asset):
     """
-    A Vector asset.
+    A Tensor asset.
     """
 
-    ASSET_TYPE = "Vector"
+    ASSET_TYPE = "Tensor"
 
     def __init__(
         self,
-        vector,
+        tensor,
         metadata=None,
         unserialize=False,
     ):
         """
-        Create a vector asset.
+        Create a tensor asset.
 
         Args:
-            vector: a vector (possibly-nested list of numbers)
+            tensor: a tensor (possibly-nested list of numbers)
 
         Example:
 
@@ -41,15 +41,15 @@ class Vector(Asset):
         >>> import kangas as kg
         >>> dg = kg.DataGrid()
         >>> for row in rows:
-        >>>     vector = row[0]
-        >>>     kg.append([kg.Vector(vector)])
-        >>> dg.save("vectors.datagrid")
+        >>>     tensor = row[0]
+        >>>     kg.append([kg.Tensor(tensor)])
+        >>> dg.save("tensors.datagrid")
         ```
         """
         super().__init__()
         if unserialize:
             return
 
-        self.asset_data = json.dumps(vector)
+        self.asset_data = json.dumps(tensor)
         if metadata:
             self.metadata.update(metadata)

--- a/frontend/lib/consts/cellMap.js
+++ b/frontend/lib/consts/cellMap.js
@@ -46,7 +46,7 @@ const cellMap = {
         component: JSONCell
 
     },
-    'VECTOR-ASSET': {
+    'TENSOR-ASSET': {
         width: 100,
         groupedWidth: 100,
         component: NACell


### PR DESCRIPTION
To avoid confusion with the JSON-based vector, rename Vector to kangas.Tensor().