### PR TITLE
Add copy-to-clipboard when click on histogram or category bar

### DIFF
--- a/frontend/app/cells/charts/Charts.module.scss
+++ b/frontend/app/cells/charts/Charts.module.scss
@@ -1,53 +1,33 @@
 .plotly-chart {
     height: 100%;
-    width: 100%;
     max-height: 110px;
 
     * {
         max-height: 110px;
-        width: 100%;
-//        max-width: 100px;
     }
 
     &.expanded {
-        min-width: 600px;
         max-height: unset;
-        max-width: unset;
-
-        div {
-            width: 75%;
-        }
 
         * {
             max-height: unset;
-            max-width: unset;
         }
     }
 }
 
 .plotly-chart-with-stats {
     height: 100%;
-    width: 100%;
     max-height: 110px;
 
     * {
         max-height: 110px;
-        width: 100%;
-//        max-width: 100px;
     }
 
     &.expanded {
-        min-width: 400px;
         max-height: unset;
-        max-width: unset;
-
-        div {
-            width: 75%;
-        }
 
         * {
             max-height: unset;
-            max-width: unset;
         }
     }
 }
@@ -55,7 +35,6 @@
 .plotly-container {
     &.expanded {
         height: 100%;
-        width: 75%;
     }
 
 }
@@ -63,7 +42,6 @@
 .plotly-container-with-stats {
     &.expanded {
         height: 100%;
-        width: 80%;
     }
 
 }

--- a/frontend/app/cells/charts/category/CategoryClient.js
+++ b/frontend/app/cells/charts/category/CategoryClient.js
@@ -89,7 +89,7 @@ const VisibleWrapper = (props) => {
 }
 
 
-const CategoryClient = ({ expanded, value, ssrData, query, columnName }) => {
+const CategoryClient = ({ expanded, value, ssrData }) => {
     const { config } = useContext(ConfigContext);
     const [response, setResponse] = useState(false);
     const data = useMemo(() => ssrData || response, [ssrData, response]);

--- a/frontend/app/cells/charts/category/CategoryClient.js
+++ b/frontend/app/cells/charts/category/CategoryClient.js
@@ -39,10 +39,16 @@ const CategoryLayout = {
         showticklabels: true,
         type: 'category',
     },
+    modebar: {
+        orientation: 'v',
+    },
 };
 
 const CategoryConfig = {
-    displayModeBar: false,
+    displayModeBar: true,
+    showAxisDragHandles: false,
+    displaylogo: false,
+    modeBarButtonsToRemove: ['select2d', 'lasso2d'],
 };
 
 const VisibleWrapper = (props) => {
@@ -83,7 +89,7 @@ const VisibleWrapper = (props) => {
 }
 
 
-const CategoryClient = ({ expanded, value, ssrData }) => {
+const CategoryClient = ({ expanded, value, ssrData, query, columnName }) => {
     const { config } = useContext(ConfigContext);
     const [response, setResponse] = useState(false);
     const data = useMemo(() => ssrData || response, [ssrData, response]);
@@ -106,6 +112,9 @@ const CategoryClient = ({ expanded, value, ssrData }) => {
             yaxis: {
                 type: 'category'
                 },
+            modebar: {
+                orientation: 'v',
+            },
         };
     }, [value?.columnName]);
 
@@ -138,6 +147,21 @@ const CategoryClient = ({ expanded, value, ssrData }) => {
         return <img src={`${config.rootPath}api/charts?${queryString}`} loading="lazy" className={cx(['chart-thumbnail', 'category'])} />
     }
 
+    const copyTextToClipboard = async (text) => {
+	if ('clipboard' in navigator) {
+	    return await navigator.clipboard.writeText(text);
+	} else {
+	    return document.execCommand('copy', true, text);
+	}
+    };
+
+    const onClick = useCallback(async (figure) => {
+	if (figure) {
+            const text = `{"${value.groupBy}"} == "${value.columnValue}" and {"${value.columnName}"} == '${figure.points[0].label}'`;
+	    await copyTextToClipboard(text);
+	}
+    }, [value]);
+
     return (
         <div className={cx('plotly-container', { expanded })}>
             { data &&
@@ -146,6 +170,7 @@ const CategoryClient = ({ expanded, value, ssrData }) => {
                 data={data}
                 layout={expanded ? ExpandedLayout : CategoryLayout}
                 config={CategoryConfig}
+	        onClick={onClick}
             />
             }
         </div>

--- a/frontend/app/cells/charts/histogram/HistogramClient.js
+++ b/frontend/app/cells/charts/histogram/HistogramClient.js
@@ -37,10 +37,16 @@ const HistogramLayout = {
         visible: true,
         showticklabels: true,
     },
+    modebar: {
+        orientation: 'v',
+    },
 };
 
 const HistogramConfig = {
-    displayModeBar: false,
+    displayModeBar: true,
+    showAxisDragHandles: false,
+    displaylogo: false,
+    modeBarButtonsToRemove: ['select2d', 'lasso2d'],
 };
 
 const VisibleWrapper = (props) => {
@@ -111,7 +117,10 @@ const HistogramClient = ({ value, expanded, ssrData }) => {
                     size: 13,
                     color: '#3D4355',
                 },
-            }
+            },
+            modebar: {
+                orientation: 'v',
+            },
         };
     }, [value?.columnName]);
 
@@ -145,6 +154,24 @@ const HistogramClient = ({ value, expanded, ssrData }) => {
         return <img src={`${config.rootPath}api/charts?${queryString}`} loading="lazy" className={cx(['chart-thumbnail', 'category'])} />
     }
 
+    const copyTextToClipboard = async (text) => {
+	if ('clipboard' in navigator) {
+	    return await navigator.clipboard.writeText(text);
+	} else {
+	    return document.execCommand('copy', true, text);
+	}
+    };
+
+    const onClick = useCallback(async (figure) => {
+	if (figure) {
+            const delta = figure.points[0].data.x[1]  - figure.points[0].data.x[0];
+            const max = figure.points[0].data.x[figure.points[0].pointIndex] + delta;
+            const min = figure.points[0].data.x[figure.points[0].pointIndex];
+            const text = `{"${value.groupBy}"} == "${value.columnValue}" and ${min} < {"${value.columnName}"} < ${max}`;
+	    await copyTextToClipboard(text);
+	}
+    }, [value]);
+
     return (
         <div style={{ minWidth: '700px', display: 'flex' }}>
             <div className={cx('plotly-container-with-stats', { expanded })}>
@@ -154,11 +181,12 @@ const HistogramClient = ({ value, expanded, ssrData }) => {
                         data={data}
                         layout={expanded ? ExpandedLayout : HistogramLayout}
                         config={HistogramConfig}
+		        onClick={onClick}
                     />
                 }
             </div>
             { !!statistics && (
-                <div style={{ margin: 'auto', marginLeft: 'inherit' }}>
+                    <div style={{ margin: 'auto', marginLeft: '50px', width: '200px' }}>
                     {Object.keys(statistics).map((key, index) => {
                         return (
                             <ul style={{ paddingLeft: '0' }}>


### PR DESCRIPTION
When you click on a histogram or category bar, copy to clipboard the criteria to select those items. You'll need to add to existing filter, if there is one. Can be used in filter or computed columns.

![click-on-category-histogram](https://user-images.githubusercontent.com/168568/234720998-2ab430be-0a70-4b85-ae1a-d73e9af6276b.gif)
