### PR TITLE
Fixed Category selection bug

### DIFF
--- a/frontend/app/cells/boolean/GroupedBooleanCell.js
+++ b/frontend/app/cells/boolean/GroupedBooleanCell.js
@@ -7,13 +7,13 @@ import styles from '../Cell.module.scss';
 
 const cx = classNames.bind(styles);
 
-const GroupedBooleanCell = ({ value, expanded = false, ssr = false }) => {
+const GroupedBooleanCell = ({ query, value, expanded = false, ssr = false }) => {
     const primitive = isPrimitive(value);
 
     return (
         <div className={cx(['cell', 'group', 'cell-content'], { expanded })}>
             { primitive && formatValue(value)}
-            { !primitive && <Suspense fallback={<>Loading</>}><Category value={value} expanded={expanded} ssr={ssr} /></Suspense>}
+            { !primitive && <Suspense fallback={<>Loading</>}><Category value={value} expanded={expanded} ssr={ssr} query={query} /></Suspense>}
         </div>
     );
 }

--- a/frontend/app/cells/charts/category/Category.js
+++ b/frontend/app/cells/charts/category/Category.js
@@ -1,11 +1,12 @@
 import fetchCategory from "@kangas/lib/fetchCategory"
 import CategoryClient from './CategoryClient';
 
-const Category = async ({ value, expanded, ssr }) => {
+const Category = async ({ query, value, expanded, ssr }) => {
     const ssrData = ssr ? await fetchCategory(value, ssr) : false;
 
     return (
         <CategoryClient
+            query={query}
             expanded={expanded}
             value={value}
             ssrData={ssrData}

--- a/frontend/app/cells/text/GroupedTextCell.js
+++ b/frontend/app/cells/text/GroupedTextCell.js
@@ -7,13 +7,13 @@ import styles from '../Cell.module.scss';
 
 const cx = classNames.bind(styles);
 
-const GroupedTextCell = ({ value, expanded = false, ssr}) => {
+const GroupedTextCell = ({ query, value, expanded = false, ssr}) => {
     const primitive = isPrimitive(value);
 
     return (
         <div className={cx(['cell', 'group', 'cell-content'], { expanded })}>
             { primitive && formatValue(value)}
-            { !primitive && <Suspense fallback={<>Loading</>}><Category value={value} expanded={expanded} ssr={ssr} /></Suspense>}
+            { !primitive && <Suspense fallback={<>Loading</>}><Category value={value} expanded={expanded} ssr={ssr} query={query} /></Suspense>}
         </div>
     );
 }


### PR DESCRIPTION
When you click on a category chart bar, it sets the clipboard to be able to select the items in that bar. In order to create proper Python (to create proper SQL) you need to know whether the column values (groupBy and the specific column) are strings or not. To get this information, we get the metadata for the datagrid, and look at "type" to see if it "TEXT". If so, we put quotes around it, otherwise use the unquoted value.

For example, if you group on column target, and click on the category bar of row-id, it should produce the expression copied to the clipboard:

```
{"target"} == "malignant" and {"row-id"} == 19
```

Note that malignant is quoted, and 19 is not. We know how, because of the metadata.