### PR TITLE
Fix dynamic update bug

### DIFF
--- a/frontend/app/Polling.js
+++ b/frontend/app/Polling.js
@@ -13,7 +13,7 @@ const Polling = ({ children }) => {
 
         const mostRecent = await fetchTimestamp(params.datagrid, false);
 
-        if (params?.timestamp !== mostRecent) {
+        if (params?.timestamp != mostRecent) {
             updateParams({ timestamp: mostRecent })
         }
     }, [params?.datagrid, params?.timestamp, updateParams])
@@ -21,7 +21,7 @@ const Polling = ({ children }) => {
     useEffect(() => {
         if (!!interval.current) clearInterval(interval.current);
 
-        interval.current = setInterval(checkTimestamp, 30000);
+        interval.current = setInterval(checkTimestamp, 3000);
 
         return () => clearInterval(interval.current);
       }, [checkTimestamp]);

--- a/frontend/app/Polling.js
+++ b/frontend/app/Polling.js
@@ -21,7 +21,7 @@ const Polling = ({ children }) => {
     useEffect(() => {
         if (!!interval.current) clearInterval(interval.current);
 
-        interval.current = setInterval(checkTimestamp, 3000);
+        interval.current = setInterval(checkTimestamp, 30000);
 
         return () => clearInterval(interval.current);
       }, [checkTimestamp]);

--- a/frontend/app/cells/charts/category/Category.js
+++ b/frontend/app/cells/charts/category/Category.js
@@ -2,11 +2,10 @@ import fetchCategory from "@kangas/lib/fetchCategory"
 import CategoryClient from './CategoryClient';
 
 const Category = async ({ query, value, expanded, ssr }) => {
-    const ssrData = ssr ? await fetchCategory(value, ssr) : false;
+    const ssrData = ssr ? await fetchCategory({ ...value, ...query }, ssr) : false;
 
     return (
         <CategoryClient
-            query={query}
             expanded={expanded}
             value={value}
             ssrData={ssrData}

--- a/frontend/app/cells/charts/histogram/Histogram.js
+++ b/frontend/app/cells/charts/histogram/Histogram.js
@@ -1,8 +1,8 @@
 import fetchHistogram from "@kangas/lib/fetchHistogram"
 import HistogramClient from "./HistogramClient";
 
-const Histogram = async ({ value, expanded, ssr }) => {
-    const ssrData = ssr ? await fetchHistogram(value, ssr) : false;
+const Histogram = async ({ query, value, expanded, ssr }) => {
+    const ssrData = ssr ? await fetchHistogram({ ...value, ...query }, ssr) : false;
 
     return <HistogramClient expanded={expanded} value={value} ssrData={ssrData} />;
 }

--- a/frontend/app/cells/charts/histogram/HistogramClient.js
+++ b/frontend/app/cells/charts/histogram/HistogramClient.js
@@ -15,6 +15,7 @@ const Plot = dynamic(() => import("react-plotly.js"), {
 
 import classNames from 'classnames/bind';
 import styles from '../Charts.module.scss';
+import useQueryParams from '@kangas/lib/hooks/useQueryParams';
 const cx = classNames.bind(styles);
 
 const HistogramLayout = {
@@ -91,6 +92,7 @@ const VisibleWrapper = (props) => {
 
 const HistogramClient = ({ value, expanded, ssrData }) => {
     const { config } = useContext(ConfigContext);
+    const { params } = useQueryParams();
     const [response, setResponse] = useState();
     const data = useMemo(() => ssrData || response, [ssrData, response]);
     const [open, setOpen] = useState(false);
@@ -133,9 +135,10 @@ const HistogramClient = ({ value, expanded, ssrData }) => {
 
         return formatQueryArgs({
             chartType: 'histogram',
-            data: JSON.stringify(data)
+            data: JSON.stringify(data),
+            timestamp: params?.timestamp
         });
-    }, [data]);
+    }, [data, params?.timestamp]);
 
 
     useEffect(() => {

--- a/frontend/app/cells/date/BaseDateCell.js
+++ b/frontend/app/cells/date/BaseDateCell.js
@@ -6,10 +6,7 @@ const cx = classNames.bind(styles);
 
 const DateCell = ({ value, style }) => {
     return (
-            <div className={cx("cell-content")} style={style}>{`${formatValue(
-            value,
-            'DATETIME'
-        )}`}</div>
+            <div className={cx("cell-content")} style={style}>{`${formatValue(value, 'DATETIME')}`}</div>
     );
 };
 

--- a/frontend/lib/fetchAbout.js
+++ b/frontend/lib/fetchAbout.js
@@ -10,7 +10,8 @@ const fetchAbout = async (query) => {
 			url: `${config.apiUrl}about`,
 			query: {
 				dgid: query.dgid,
-				url: `${config.rootUrl}`
+				url: `${config.rootUrl}`,
+				timestamp: query?.timestamp
 			}
 		});
 		return data?.about;

--- a/frontend/lib/fetchCategory.js
+++ b/frontend/lib/fetchCategory.js
@@ -10,8 +10,8 @@ const fetchCategory = async (query, ssr=false) => {
     //const data = await fetch(`http://localhost:4000/category?${queryString}`)
 
     const data = ssr ?
-        await fetchIt({ url: `${config.apiUrl}category`, query}) :
-        await fetchIt({url: `${config.rootPath}api/category`, query});
+        await fetchIt({ url: `${config.apiUrl}category`, query }) :
+        await fetchIt({ url: `${config.rootPath}api/category`, query });
 
     if (data?.error) {
         return data;

--- a/frontend/lib/fetchDatagridTotal.js
+++ b/frontend/lib/fetchDatagridTotal.js
@@ -6,15 +6,8 @@ import fetchIt from './fetchIt';
 
 const fetchDatagridTotal = async (query) => {
     if (query?.dgid) {
-	const myQuery = {
-	    dgid: query.dgid,
-	    whereExpr: query.whereExpr,
-	    groupBy: query.groupBy,
-	    computedColumns: query.computedColumns,
-	};
 
-	const data = await fetchIt({ url: `${config.apiUrl}query-total`,
-				     query: myQuery });
+	const data = await fetchIt({ url: `${config.apiUrl}query-total`, query });
 	return data; // {"total": int}
     }
     return {"total": 0};


### PR DESCRIPTION
Some queries don't have timestamps, and therefore cache their results without regard for updates to the underlying datagrid. This fixes that.