### PR TITLE
Remove dynamic updates

### DIFF
--- a/backend/kangas/__init__.py
+++ b/backend/kangas/__init__.py
@@ -172,7 +172,6 @@ def show(
     if datagrid:
         query_vars = {
             "datagrid": datagrid,
-            "timestamp": os.path.getmtime(datagrid),
         }
         query_vars.update(kwargs)
         if filter:

--- a/backend/kangas/cli/server.py
+++ b/backend/kangas/cli/server.py
@@ -350,7 +350,6 @@ def server(parsed_args, remaining=None):
                 raise Exception("Unknown file type: %r" % file_type)
 
             query_vars["datagrid"] = filename
-            query_vars["timestamp"] = os.path.getmtime(filename)
             if parsed_args.filter:
                 query_vars["filter"] = parsed_args.filter
             if parsed_args.group:

--- a/backend/kangas/datatypes/datagrid.py
+++ b/backend/kangas/datatypes/datagrid.py
@@ -347,8 +347,7 @@ class DataGrid:
             self.save()
 
         query_vars = {
-            "datagrid": self.filename,
-            "timestamp": os.path.getmtime(self.filename),
+            "datagrid": self.filename
         }
         query_vars.update(kwargs)
 

--- a/frontend/app/PagerBar/index.js
+++ b/frontend/app/PagerBar/index.js
@@ -4,29 +4,26 @@ import fetchDataGridTotal from '@kangas/lib/fetchDatagridTotal';
 import fetchAbout from '@kangas/lib/fetchAbout';
 import Pager from './pager';
 
-const PagerBar = async ({query}) => {
+const PagerBar = async ({ query }) => {
     const totalRows = (await fetchDataGridTotal(query)).total;
     const aboutText = await fetchAbout(query);
 
     const firstRow = query.offset + 1;
     const currentPage = Math.floor(query.offset / query.limit) + 1;
     const totalPages = Math.ceil(totalRows / query.limit);
-    const maxRow = Math.min(
-	query.offset + query.limit,
-	totalRows,
-    );
+    const maxRow = Math.min(query.offset + query.limit, totalRows);
     const pageSize = query.limit;
 
     return (
 	    <Pager
-              dgid={query.dgid}
-              aboutText={aboutText}
-	      firstRow={firstRow}
-	      totalRows={totalRows}
-              currentPage={currentPage}
-	      totalPages={totalPages}
-	      maxRow={maxRow}
-	      pageSize={pageSize}
+            dgid={query.dgid}
+            aboutText={aboutText}
+            firstRow={firstRow}
+            totalRows={totalRows}
+            currentPage={currentPage}
+            totalPages={totalPages}
+            maxRow={maxRow}
+            pageSize={pageSize}
 	    />
     );
 };

--- a/frontend/app/PagerBar/pager.js
+++ b/frontend/app/PagerBar/pager.js
@@ -17,7 +17,7 @@ const cx = classNames.bind(styles);
 const Pager = ({ dgid, aboutText, firstRow, totalRows, currentPage, totalPages, maxRow, pageSize }) => {
     const { config } = useContext(ConfigContext);
     const { beginLoading } = useContext(ViewContext);
-    const { params, updateParams } = useQueryParams();
+    const { updateParams } = useQueryParams();
     const pageInput = useRef();
     const aboutButton = aboutText !== '' ? (<AboutDataGridButton text={aboutText} />) : (<></>);
     const downloadName = dgid && dgid.includes("/") ? dgid.substring(dgid.lastIndexOf("/") + 1) : dgid;

--- a/frontend/app/Settings/Buttons/RefreshButton.js
+++ b/frontend/app/Settings/Buttons/RefreshButton.js
@@ -24,7 +24,7 @@ const RefreshButton = ({ query }) => {
             filter: undefined,
             descending: undefined,
             select: undefined,
-	    cc: undefined,
+            cc: undefined,
             begin: Math.max(view?.start, 0),
             boundary: view?.stop
         });

--- a/frontend/app/Settings/MatrixSelectClient.js
+++ b/frontend/app/Settings/MatrixSelectClient.js
@@ -15,15 +15,14 @@ const cx = classNames.bind(styles);
 
 // Ideally, we wouldn't need to import a third-party library for a select component here,
 // but native select components are annoying to style
-const MatrixSelect = ({ query, options=['blah'] }) => {
-    const { params, updateParams, prefetch } = useQueryParams();
+const MatrixSelect = ({ options=['blah'] }) => {
+    const { params, updateParams } = useQueryParams();
     const { config } = useContext(ConfigContext)
     const { beginLoading } = useContext(ViewContext)
 
     const changeDatagrid = useCallback((e) => {
         updateParams({
             datagrid: e.value,
-            timestamp: e.timestamp,
             filter: undefined,
             sort: undefined,
             group: undefined,

--- a/frontend/app/Settings/index.js
+++ b/frontend/app/Settings/index.js
@@ -6,8 +6,16 @@ import fetchCompletions from '@kangas/lib/fetchCompletions';
 import MatrixSelect from './MatrixSelectClient';
 import FilterExpr from './FilterExpr';
 import HelpText from './HelpText.js';
-import { KangasButton, AboutDialog, SelectButton, HelpButton, GroupByButton,
-	 SortByButton, RefreshButton, ComputedColumnsButton } from './Buttons';
+import { 
+    KangasButton, 
+    AboutDialog,
+    SelectButton,
+    HelpButton,
+    GroupByButton,
+	SortByButton, 
+    RefreshButton, 
+    ComputedColumnsButton 
+} from './Buttons';
 import styles from './SettingsBar.module.scss';
 import classNames from 'classnames/bind';
 import { Suspense } from 'react';

--- a/frontend/app/cells/charts/category/CategoryClient.js
+++ b/frontend/app/cells/charts/category/CategoryClient.js
@@ -60,8 +60,6 @@ const VisibleWrapper = (props) => {
     });
     const timeout = useRef();
 
-    const { query } = useContext(ViewContext);
-
     const [hasRendered, setHasRendered] = useState(false);
     const visible = useMemo(() => hasRendered || inView, [hasRendered, inView]);
     const render = useCallback(() => {
@@ -97,6 +95,7 @@ const VisibleWrapper = (props) => {
 const CategoryClient = ({ expanded, value, ssrData }) => {
     const { config } = useContext(ConfigContext);
     const { params } = useQueryParams();
+    const { query } = useContext(ViewContext);
     const [response, setResponse] = useState(false);
     const data = useMemo(() => ssrData || response, [ssrData, response]);
     const [open, setOpen] = useState(false);

--- a/frontend/app/cells/charts/histogram/HistogramClient.js
+++ b/frontend/app/cells/charts/histogram/HistogramClient.js
@@ -16,6 +16,7 @@ const Plot = dynamic(() => import("react-plotly.js"), {
 import classNames from 'classnames/bind';
 import styles from '../Charts.module.scss';
 import useQueryParams from '@kangas/lib/hooks/useQueryParams';
+import { ViewContext } from '@kangas/app/contexts/ViewContext';
 const cx = classNames.bind(styles);
 
 const HistogramLayout = {
@@ -92,7 +93,7 @@ const VisibleWrapper = (props) => {
 
 const HistogramClient = ({ value, expanded, ssrData }) => {
     const { config } = useContext(ConfigContext);
-    const { params } = useQueryParams();
+    const { query } = useContext(ViewContext);
     const [response, setResponse] = useState();
     const data = useMemo(() => ssrData || response, [ssrData, response]);
     const [open, setOpen] = useState(false);
@@ -136,9 +137,9 @@ const HistogramClient = ({ value, expanded, ssrData }) => {
         return formatQueryArgs({
             chartType: 'histogram',
             data: JSON.stringify(data),
-            timestamp: params?.timestamp
+            timestamp: query?.timestamp
         });
-    }, [data, params?.timestamp]);
+    }, [data, query?.timestamp]);
 
 
     useEffect(() => {

--- a/frontend/app/contexts/ViewContext.js
+++ b/frontend/app/contexts/ViewContext.js
@@ -98,7 +98,8 @@ const ViewProvider = ({ value, children }) => {
             updateView: (payload) => dispatch({ type: 'UPDATE_VIEW', payload }),
             beginLoading: () => dispatch({ type: 'BEGIN_LOADING' }),
             completeLoading: () => dispatch({ type: 'COMPLETE_LOADING'}),
-            isLoading: state?.isLoading
+            isLoading: state?.isLoading,
+            query: state?.query
         }}>
             { children }
         </ViewContext.Provider>

--- a/frontend/app/modals/ComputedColumnsModal/ExpressionEditor.js
+++ b/frontend/app/modals/ComputedColumnsModal/ExpressionEditor.js
@@ -7,13 +7,20 @@ import formatQueryArgs from '@kangas/lib/formatQueryArgs';
 import styles from './ExpressionEditor.module.scss';
 import classNames from 'classnames/bind';
 import { ConfigContext } from "@kangas/app/contexts/ConfigContext";
+import { ViewContext } from '@kangas/app/contexts/ViewContext';
 
 const cx = classNames.bind(styles);
 
-const ExpressionEditor = ({ key, className, style, expression, completions,
-                            computedColumns, onChange }) => {
+const ExpressionEditor = ({ 
+    style, 
+    expression, 
+    completions,             
+    computedColumns, 
+    onChange 
+}) => {
     const { config } = useContext(ConfigContext);
     const { params, updateParams } = useQueryParams();
+    const { query } = useContext(ViewContext);
     const expressionRef = useRef();
     const timeout = useRef();
     const [status, setStatus] = useState();
@@ -23,7 +30,7 @@ const ExpressionEditor = ({ key, className, style, expression, completions,
 
         const queryString = formatQueryArgs({
             dgid: params?.datagrid,
-            timestamp: params?.timestamp,
+            timestamp: query?.timestamp,
             where: text,
             computedColumns: computedColumns,
         });
@@ -39,7 +46,7 @@ const ExpressionEditor = ({ key, className, style, expression, completions,
             // FIXME? set the field regardless of validity
             onChange({target: {value: text}});
         });
-    }, [params]);
+    }, [params, query]);
 
     // Debounce call to verify-filter so that we don't spam the endpoint
     const editorOnChange = useCallback((text) => {

--- a/frontend/app/modals/ComputedColumnsModal/index.js
+++ b/frontend/app/modals/ComputedColumnsModal/index.js
@@ -46,7 +46,6 @@ const ComputedColumnsModal = ({ columns, query, completions }) => {
       // Verify that this works, with (or without) filter:
       const queryString = formatQueryArgs({
         dgid: query?.dgid,
-        timestamp: query?.timestamp,
         where: query?.whereExpr,
         computedColumns: computedColumns
       });

--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -80,7 +80,7 @@ const Page = async ({ searchParams }) => {
     }
 
     return (
-        <Polling>
+        <>
             <Imports />
             <Suspense fallback={<Skeleton message={"Suspending Page"} />}>
                 <Main query={query} />
@@ -88,7 +88,7 @@ const Page = async ({ searchParams }) => {
             <Suspense fallback={<></>}>
                 <Prefetch datagrids={datagrids} query={query} />
             </Suspense>
-        </Polling>
+        </>
     );
 };
 

--- a/frontend/lib/fetchCompletions.js
+++ b/frontend/lib/fetchCompletions.js
@@ -5,7 +5,7 @@ import config from '@kangas/config';
 import fetchIt from './fetchIt';
 
 const fetchCompletions = async ( dgid, timestamp, computedColumns ) => {
-    if (!!dgid) {
+    if (!!dgid && !!timestamp) {
         const data = await fetchIt({
             url: `${config.apiUrl}completions`,
             query: {dgid, timestamp, computedColumns}

--- a/frontend/lib/fetchMetadata.js
+++ b/frontend/lib/fetchMetadata.js
@@ -4,7 +4,7 @@ import config from '@kangas/config';
 // Utils
 import fetchIt from './fetchIt';
 
-const fetchMetadata = async ({query, ssr=true}) => {
+const fetchMetadata = async ({ query, ssr=true }) => {
     const data = ssr ?
         await fetchIt({ url: `${config.apiUrl}metadata`, query }) :
         await fetchIt({ url: `${config.rootPath}api/metadata`, query });


### PR DESCRIPTION
Remove the dynamic updates. Users can now refresh datagrid data by reloading the window.