### PR TITLE
Remove timestamp from URL

### DIFF
--- a/frontend/app/Polling.js
+++ b/frontend/app/Polling.js
@@ -1,36 +1,31 @@
 'use client';
 
 import fetchTimestamp from "@kangas/lib/fetchTimestamp";
-import useQueryParams from "@kangas/lib/hooks/useQueryParams";
 import { useCallback, useContext, useEffect, useRef } from "react";
 import { ViewContext } from "./contexts/ViewContext";
 
 const Polling = ({ children }) => {
-    const { params, updateParams } = useQueryParams();
+    const { query } = useContext(ViewContext);
     const { shouldPoll } = useContext(ViewContext);
     const interval = useRef();
 
     const checkTimestamp = useCallback(async () => {
-        if (!params?.datagrid || !shouldPoll) return;
+        if (!query?.dgid) return;
 
-        const mostRecent = await fetchTimestamp(params.datagrid, false);
+        const mostRecent = await fetchTimestamp(query.datagrid, false);
 
-        if (params?.timestamp != mostRecent) {
-            updateParams({ timestamp: mostRecent })
+        if (query?.timestamp != mostRecent) {
+            window.location.reload(false);
         }
-    }, [params?.datagrid, params?.timestamp, updateParams, shouldPoll])
+    }, [query?.dgid, query?.timestamp, shouldPoll])
 
     useEffect(() => {
-        if (!params?.timestamp) {
-            checkTimestamp();
-        } else {
-            if (!!interval.current) clearInterval(interval.current);
+        if (!!interval.current) clearInterval(interval.current);
 
-            interval.current = setInterval(checkTimestamp, 15000);
-        }
+        interval.current = setInterval(checkTimestamp, 15000);
 
         return () => clearInterval(interval.current);
-      }, [checkTimestamp, params?.timestamp]);
+    }, [checkTimestamp, query]);
       
       return (
         <>

--- a/frontend/app/Polling.js
+++ b/frontend/app/Polling.js
@@ -12,7 +12,7 @@ const Polling = ({ children }) => {
     const router = useRouter();
 
     const checkTimestamp = useCallback(async () => {
-        if (!query?.dgid) return;
+        if (!query?.dgid || !shouldPoll) return;
 
         const mostRecent = await fetchTimestamp(query.datagrid, false);
 

--- a/frontend/app/Polling.js
+++ b/frontend/app/Polling.js
@@ -1,6 +1,7 @@
 'use client';
 
 import fetchTimestamp from "@kangas/lib/fetchTimestamp";
+import { useRouter } from "next/navigation";
 import { useCallback, useContext, useEffect, useRef } from "react";
 import { ViewContext } from "./contexts/ViewContext";
 
@@ -8,6 +9,7 @@ const Polling = ({ children }) => {
     const { query } = useContext(ViewContext);
     const { shouldPoll } = useContext(ViewContext);
     const interval = useRef();
+    const router = useRouter();
 
     const checkTimestamp = useCallback(async () => {
         if (!query?.dgid) return;
@@ -15,7 +17,8 @@ const Polling = ({ children }) => {
         const mostRecent = await fetchTimestamp(query.datagrid, false);
 
         if (query?.timestamp != mostRecent) {
-            window.location.reload(false);
+            const { pathname, search } = window.location;
+            router.replace(`${pathname}${search}`);
         }
     }, [query?.dgid, query?.timestamp, shouldPoll])
 

--- a/frontend/app/Settings/Buttons/RefreshButton.js
+++ b/frontend/app/Settings/Buttons/RefreshButton.js
@@ -24,7 +24,7 @@ const RefreshButton = ({ query }) => {
             filter: undefined,
             descending: undefined,
             select: undefined,
-	    cc: undefined,
+	        cc: undefined,
             begin: Math.max(view?.start, 0),
             boundary: view?.stop
         });

--- a/frontend/app/Settings/MatrixSelectClient.js
+++ b/frontend/app/Settings/MatrixSelectClient.js
@@ -23,7 +23,6 @@ const MatrixSelect = ({ query, options=['blah'] }) => {
     const changeDatagrid = useCallback((e) => {
         updateParams({
             datagrid: e.value,
-            timestamp: e.timestamp,
             filter: undefined,
             sort: undefined,
             group: undefined,

--- a/frontend/app/contexts/ModalContext.js
+++ b/frontend/app/contexts/ModalContext.js
@@ -18,7 +18,6 @@ const ModalProvider = ({ value, children }) => {
     }, [value?.openModal, pausePolling]);
 
     const closeModal = useCallback(() => {
-        console.log('HEY CLOSE')
         value?.closeModal();
         resumePolling();
     }, [value?.closeModal, resumePolling])

--- a/frontend/app/contexts/ViewContext.js
+++ b/frontend/app/contexts/ViewContext.js
@@ -1,7 +1,6 @@
 'use client';
 
 import { createContext, useCallback, useEffect, useReducer } from 'react';
-import useDebounce from '@kangas/lib/hooks/useDebounce';
 
 export const ViewContext = createContext();
 
@@ -98,12 +97,6 @@ const ViewProvider = ({ value, children }) => {
         }
     }, [state?.query, value?.query, dispatch])
 
-    useEffect(() => {
-        console.log('should I poll?');
-        console.log(state?.shouldPoll);
-    }, [state?.shouldPoll])
-
-
     return (
         <ViewContext.Provider value={{
             columns: state.columns,
@@ -115,7 +108,7 @@ const ViewProvider = ({ value, children }) => {
             completeLoading: () => dispatch({ type: 'COMPLETE_LOADING'}),
             pausePolling: () => dispatch({ type: 'PAUSE_POLLING' }),
             resumePolling: () => dispatch({ type: 'RESUME_POLLING' }),
-            shouldPoll: state.shouldPoll,
+            shouldPoll: !!state?.shouldPoll,
             isLoading: state?.isLoading
         }}>
             { children }

--- a/frontend/app/contexts/ViewContext.js
+++ b/frontend/app/contexts/ViewContext.js
@@ -109,7 +109,8 @@ const ViewProvider = ({ value, children }) => {
             pausePolling: () => dispatch({ type: 'PAUSE_POLLING' }),
             resumePolling: () => dispatch({ type: 'RESUME_POLLING' }),
             shouldPoll: !!state?.shouldPoll,
-            isLoading: state?.isLoading
+            isLoading: state?.isLoading,
+            query: state?.query
         }}>
             { children }
         </ViewContext.Provider>

--- a/frontend/app/page.js
+++ b/frontend/app/page.js
@@ -70,10 +70,9 @@ const Page = async ({ searchParams }) => {
         limit,
         boundary,
         begin,
-        timestamp
     };
 
-    if (!!datagrid && !timestamp) {
+    if (!!datagrid) {
         query.timestamp = await fetchTimestamp(datagrid);
     } 
 


### PR DESCRIPTION
Previously, we stored the timestamp in the URL along with other parts of Kangas' state. We also used the updating of the timestamp URL query param as an implicit reload of the page. To remove the timestamp from the URL, we instead store the timestamp in the query object within ViewContext, and trigger reloads in our Polling component by calling window.reload() directly.