### PR TITLE
Refactor loading spinner

### DIFF
--- a/frontend/app/Table/TableClientWrapper.js
+++ b/frontend/app/Table/TableClientWrapper.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { CircularProgress } from "@mui/material";
+import { CircularProgress, Dialog } from "@mui/material";
 import { useContext, useEffect, useRef } from "react"
 import { ViewContext } from "@kangas/app/contexts/ViewContext"
 
@@ -15,29 +15,21 @@ const TableClientWrapper = ({ data, children }) => {
         }
     }, [data, completeLoading, isLoading]);
 
-    if (isLoading) {
         return (
-            <div>
-                <div
-                    style={{
-                        position: 'absolute',
-                        width: '100%',
-                        height: '100%',
-                        display: 'flex',
-                        justifyContent: 'center',
-                        alignItems: 'center',
-                    }}
+            <>
+                <Dialog open={isLoading}
+                  PaperProps={{
+                    style: {
+                      backgroundColor: 'transparent',
+                      boxShadow: 'none',
+                    },
+                  }}
                 >
-                    <div >
                         <CircularProgress />
-                    </div>
-                </div>
+                </Dialog>
                 { children }
-            </div>
+            </>
         )
-    } else {
-        return <>{ children }</>
-    }
 }
 
 export default TableClientWrapper;


### PR DESCRIPTION
Currently, the loading spinner does not lay on top of the page correctly and moves the scrollbox. This reimplements the spinner using MUI's Dialog modal, putting the loading spinner in the center of the screen without interfering with any elements "beneath" it