### PR TITLE
Fix debounce issue in filter bar

### DIFF
--- a/frontend/app/Settings/FilterExpr.js
+++ b/frontend/app/Settings/FilterExpr.js
@@ -20,9 +20,9 @@ const FilterExpr = ({ query, completions }) => {
 
     // If the filter is cleared in the refresh button:
     useEffect(() => {
-	if (typeof query?.whereExpr === "undefined" && filterText != '') {
-	    setFilterText('');
-	}
+        if (typeof query?.whereExpr === "undefined" && filterText != '') {
+            setFilterText('');
+        }
     }, [query?.whereExpr]);
 
     const fetchValidity = useCallback((filter) => {
@@ -49,20 +49,17 @@ const FilterExpr = ({ query, completions }) => {
     // Debounce call to verify-filter so that we don't spam the endpoint
     const onChange = useCallback((filter) => {
         setFilterText(filter);
-        if (status !== 'LOADING') {
-            try {
-                clearTimeout(timeout.current)
-            } catch {
+        try {
+            clearTimeout(timeout.current)
+        } catch {
 
-            } finally {
-                timeout.current = setTimeout(() => fetchValidity(filter), 150)
-            }
+        } finally {
+            timeout.current = setTimeout(() => fetchValidity(filter), 150)
         }
-    }, [fetchValidity, status]);
+    }, [fetchValidity]);
 
     const getValue = (value) => {
-        if (typeof(value) === 'undefined' || value === '')
-            return undefined;
+        if (typeof(value) === 'undefined' || value === '') return undefined;
         return value;
     };
 

--- a/frontend/app/Settings/index.js
+++ b/frontend/app/Settings/index.js
@@ -30,11 +30,11 @@ const SettingsBar = async ({ query }) => {
         <div className={cx('settings-bar')}>
             <div className={cx('left-settings-bar')}>
                 <DialogueModal fullScreen={false} toggleElement={<KangasButton />}>
-                    <Suspense fallback={<div>Loading</div>}>
+                    <Suspense fallback={<div>Loading...</div>}>
                         <AboutDialog status={status} />
                     </Suspense>
                 </DialogueModal>
-                <Suspense fallback={<>FDKLSF</>}>
+                <Suspense fallback={<>Loading...</>}>
                     <MatrixSelect query={query} options={options} />
                 </Suspense>
                 <RefreshButton query={query} />


### PR DESCRIPTION
In certain circumstances, the filter bar will flag a valid filter expression as invalid and prevent submission. This fixes the issue by removing an unnecessary check performed by the validator function.